### PR TITLE
Merging migrate-db-jace & migrate-db-marcus to migrate-db-integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,7 +71,10 @@ consumer_manager = None
 
 def create_app():
     from pear_schedule.api.routes import router as sched_router
-    app = FastAPI()
+    app = FastAPI(
+        title="PEAR FYP Scheduler Service",
+        description="Scheduler Service API Documentation"
+    )
     app.include_router(sched_router, prefix="/schedule")
     #Add Origins so CORS allows these URLS to pass through so Front-end to be able to call APIs
     origins = [

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -308,8 +308,13 @@ class CompulsoryActivitiesOnlyView(BaseView): # Just compulsory activities only
             centre_activity.c["FixedTimeSlots"],
         ).join(
             activity, activity.c["ActivityID"] == centre_activity.c["ActivityID"]
-        ).where(centre_activity.c["IsCompulsory"] == True
-        ).where(centre_activity.c["EndDate"] > get_next_sunday()) #EndDate has been moved from ActivityTable to CentreActivity Table
+        ).where(
+            centre_activity.c["IsCompulsory"] == True,
+            or_ (
+                centre_activity.c["EndDate"] > get_next_sunday(),
+                centre_activity.c["EndDate"] == None
+            )
+        ) #EndDate has been moved from ActivityTable to CentreActivity Table
 
         return query
     

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -203,7 +203,9 @@ class GroupActivitiesOnlyView(BaseView): # Just group activities only
             activity, activity.c["ActivityID"] == centre_activity.c["ActivityID"]
         ).where(centre_activity.c["IsGroup"] == True
         ).where(centre_activity.c["IsCompulsory"] == False
-        ).where(centre_activity.c["EndDate"] > get_next_sunday()) #EndDate has been moved from ActivityTable to CentreActivity Table
+        ).where(or_(
+        centre_activity.c["EndDate"] > get_next_sunday(),
+        centre_activity.c["EndDate"].is_(None))) #EndDate has been moved from ActivityTable to CentreActivity Table
 
         return query
     
@@ -309,7 +311,9 @@ class CompulsoryActivitiesOnlyView(BaseView): # Just compulsory activities only
         ).join(
             activity, activity.c["ActivityID"] == centre_activity.c["ActivityID"]
         ).where(centre_activity.c["IsCompulsory"] == True
-        ).where(centre_activity.c["EndDate"] > get_next_sunday()) #EndDate has been moved from ActivityTable to CentreActivity Table
+        ).where(or_(
+        centre_activity.c["EndDate"] > get_next_sunday(),
+        centre_activity.c["EndDate"].is_(None))) #EndDate has been moved from ActivityTable to CentreActivity Table
 
         return query
     

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -311,6 +311,7 @@ class CompulsoryActivitiesOnlyView(BaseView): # Just compulsory activities only
         ).join(
             activity, activity.c["ActivityID"] == centre_activity.c["ActivityID"]
         ).where(centre_activity.c["IsCompulsory"] == True
+        ).where(centre_activity.c["IsDeleted"] == False
         ).where(or_(
         centre_activity.c["EndDate"] > get_next_sunday(),
         centre_activity.c["EndDate"].is_(None))) #EndDate has been moved from ActivityTable to CentreActivity Table

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -497,12 +497,13 @@ class WeeklyScheduleView(BaseView): # Get the weekly schedule for all patients
         schema = DB.schema
         
         schedule = schema.tables[cls.db_tables.SCHEDULE_TABLE]
-        
+        patient = schema.tables[cls.db_tables.PATIENT_TABLE]
         curDateTime = datetime.now()
-        
+        subquery = select(patient.c.PreferredName).where(patient.c.PatientID == schedule.c.PatientID).scalar_subquery()
         query: Select = select(
             schedule.c["ScheduleID"],
             schedule.c["PatientID"],
+            subquery.label("PreferredName"),
             schedule.c["Monday"],
             schedule.c["Tuesday"],
             schedule.c["Wednesday"],

--- a/pear_schedule/scheduler/compulsoryScheduling.py
+++ b/pear_schedule/scheduler/compulsoryScheduling.py
@@ -8,14 +8,13 @@ class CompulsoryActivityScheduler(BaseScheduler):
         compulsoryActivitiesDF = CompulsoryActivitiesOnlyView.get_data()
         
         # Compulsory Activity 
-        for activityTitle in compulsoryActivitiesDF["ActivityTitle"]:
-            fixedSlotString = compulsoryActivitiesDF.query(f"ActivityTitle == '{activityTitle}'").iloc[0]['FixedTimeSlots']
+        for _, row in compulsoryActivitiesDF.loc[:, ["ActivityTitle", "FixedTimeSlots"]].astype(str).iterrows():
 
-            fixedSlotArr = fixedSlotString.split(",")
+            fixedSlotArr = row["FixedTimeSlots"].split(",")
             for slot in fixedSlotArr:
                 day = int(slot.split("-")[0])
                 hour = int(slot.split("-")[1])
 
                 for pid in patientSchedules.keys():
-                    patientSchedules[pid][day][hour] = activityTitle 
+                    patientSchedules[pid][day][hour] = row["ActivityTitle"]
 

--- a/pear_schedule/scheduler/compulsoryScheduling.py
+++ b/pear_schedule/scheduler/compulsoryScheduling.py
@@ -6,7 +6,6 @@ class CompulsoryActivityScheduler(BaseScheduler):
     @classmethod
     def fillSchedule(cls, patientSchedules: Mapping[str, List[str]]):
         compulsoryActivitiesDF = CompulsoryActivitiesOnlyView.get_data()
-        breakpoint()
         # Compulsory Activity 
         for activityTitle in compulsoryActivitiesDF["ActivityTitle"]:
             fixedSlotString = compulsoryActivitiesDF.query(f"ActivityTitle == '{activityTitle}'").iloc[0]['FixedTimeSlots']

--- a/pear_schedule/scheduler/compulsoryScheduling.py
+++ b/pear_schedule/scheduler/compulsoryScheduling.py
@@ -6,7 +6,7 @@ class CompulsoryActivityScheduler(BaseScheduler):
     @classmethod
     def fillSchedule(cls, patientSchedules: Mapping[str, List[str]]):
         compulsoryActivitiesDF = CompulsoryActivitiesOnlyView.get_data()
-        
+        breakpoint()
         # Compulsory Activity 
         for activityTitle in compulsoryActivitiesDF["ActivityTitle"]:
             fixedSlotString = compulsoryActivitiesDF.query(f"ActivityTitle == '{activityTitle}'").iloc[0]['FixedTimeSlots']

--- a/pear_schedule/scheduler/groupScheduling.py
+++ b/pear_schedule/scheduler/groupScheduling.py
@@ -242,7 +242,7 @@ class GroupActivityScheduler(BaseScheduler):
             isFixed = groupActivityDF.query(f"ActivityTitle == '{activity}'").iloc[0]['IsFixed']
             
             # for fixed time activity, try all given fixed timeslots
-            if isFixed:
+            if int(isFixed) == 1:
                 fixedTimeSlots = groupActivityDF.query(f"ActivityTitle == '{activity}'").iloc[0]['FixedTimeSlots']
                 possibleTimeSlots = cls.getFixedTimeArr(fixedTimeSlots)
 

--- a/pear_schedule/scheduler/individualScheduling.py
+++ b/pear_schedule/scheduler/individualScheduling.py
@@ -44,12 +44,10 @@ class IndividualActivityScheduler(BaseScheduler):
                     "preferences":dict(), "exclusions": dict(), "dispreferences": dict()  # recommendations handled in compulsory scheduling
                 }
             
-                # If ActivityEndDate is null, means the Activity will restart every week. #ToBeConfirmed
-            if pd.isna(p["ActivityEndDate"]):
-                p["ActivityEndDate"] = week_end
-
-            if p["ActivityEndDate"] <= week_end:
+            # If ActivityEndDate is null, means the Activity will restart every week. #ToBeConfirmed
+            if not pd.isna(p["ActivityEndDate"]) and p["ActivityEndDate"] <= week_end:
                 continue
+
 
             patients[pid]["preferences"][p["PreferredActivityID"]] = True
 
@@ -105,8 +103,8 @@ class RecommendedRoutineActivityScheduler(IndividualActivityScheduler):
             recommendations.sort_values(by=["PatientID"])
             recommendations["FixedTimeSlots"] = recommendations["FixedTimeSlots"].astype(str)
 
-            # filter out activities that are not available this week
-            recommendations = recommendations[recommendations["ActivityEndDate"] > week_end]
+            # filter out activities that are not available this week, NULL dates are indefinite
+            recommendations = recommendations[(recommendations["ActivityEndDate"] > week_end) | (recommendations["ActivityEndDate"].isna())]
 
             # add an extra row at end for easier handling of final patient
             dummy_row = recommendations.iloc[0:1].copy(deep=True)
@@ -433,8 +431,7 @@ class PreferredActivityScheduler(IndividualActivityScheduler):
             patient_data = cls._get_patient_data(conn)
             activities = ActivitiesView.get_data(conn)
             # Fill null EndDate with week_end as the current weekend (this is because activities who are indefinite have null EndDate)
-            activities["EndDate"] = activities["EndDate"].fillna(week_end)
-            activities = activities[activities["EndDate"] > week_end]
+            activities = activities[(activities["EndDate"].isna()) | (activities["EndDate"] > week_end)]
             activities_title_lookup = {
                 row["ActivityTitle"]: row["ActivityID"] for _, row in activities.iterrows()
             }


### PR DESCRIPTION
1. Modified FastAPI Title & Description to reflect service name instead of default configurations.
2. Modified individual scheduling, compulsory activities view, group scheduling to allow activities with NULL enddates to be select in queries & filter deleted activities
3. Mapped Patient's Preferred name to PatientID for /get/schedule/ endpoint. This is for frontend to be able to map each schedule with it's patientname instead of patientID for supervisor's viewing purposes.
4. Merged's Marcus' commits in modification of iloc to iterrows as iloc would is going to be deprecated & bugfixes