### PR TITLE
Disabled inactive routes & modify query to exclude deleted activities

### DIFF
--- a/pear_schedule/api/routes.py
+++ b/pear_schedule/api/routes.py
@@ -285,12 +285,12 @@ def adhoc_change_schedule(request: Request, data: AdHocRequest):
     return JSONResponse(jsonable_encoder(responseData))
 
 
+#refresh currently is disabled
+# @router.api_route("/refresh/", methods=["GET"])
+# def refresh_schedules():
+#     ScheduleRefresher.refresh_schedules()
 
-@router.api_route("/refresh/", methods=["GET"])
-def refresh_schedules():
-    ScheduleRefresher.refresh_schedules()
-
-    return PlainTextResponse("Successfully updated schedules", status_code=200)
+#     return PlainTextResponse("Successfully updated schedules", status_code=200)
 
 
 @router.api_route("/systemTest/", methods=["GET"])

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -87,6 +87,7 @@ class ActivitiesView(BaseView):
             centre_activity, activity.c["ActivityID"] == centre_activity.c["ActivityID"]
         ).where(
             centre_activity.c["IsGroup"] == False,
+            centre_activity.c["IsDeleted"] == False
         )
 
         return query
@@ -153,6 +154,7 @@ class PatientsUnpreferredView(BaseView):
         ).where(
             centre_activity_preference.c["IsLike"] == 0,
             centre_activity_preference.c["IsDeleted"] == False,
+            centre_activity.c["IsDeleted"] == False,
         ).cte()
 
         query: Select = select(


### PR DESCRIPTION
1.Disabled refresh endpoint as it is currently not being used
2. Added isDeleted into query to prevent soft deleted activities from being added in schedule.