### PR TITLE
Add tags to differentiate between scheduler and reconcilation service

### DIFF
--- a/pear_schedule/api/integrity_router.py
+++ b/pear_schedule/api/integrity_router.py
@@ -12,7 +12,7 @@ from pear_schedule.models.ref_activity_recommendation_model import RefActivityRe
 from pear_schedule.models.ref_patient_model import RefPatient
 from pear_schedule.models.ref_patient_medication_model import RefPatientMedication
 
-router = APIRouter()
+router = APIRouter(tags=["Integrity"])
 
 
 @router.get("/ref-activity")

--- a/pear_schedule/api/schedule_router.py
+++ b/pear_schedule/api/schedule_router.py
@@ -28,7 +28,7 @@ from colorama import init, Fore
 init(autoreset=True)
 
 
-router = APIRouter()
+router = APIRouter(tags=["Scheduler"])
 
 @router.api_route("/getSchedule/", methods=["GET"])
 def get_schedule(request: Request):


### PR DESCRIPTION
Swagger should separate routes between scheduler and reconcil service