### PR TITLE
Chore/mq e2e unit test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,11 +79,11 @@ def sample_schedule():
 def sample_activity_exclusion():
     """Create a sample RefActivityExclusion instance"""
     return RefActivityExclusion(
-        Id=1,
-        PatientId=1,
-        ActivityId=1,
-        StartDate=datetime(2024, 1, 1),
-        EndDate=datetime(2024, 1, 7),
+        ActivityExclusionID=1,
+        PatientID=1,
+        ActivityID=1,
+        StartDateTime=datetime(2024, 1, 1),
+        EndDateTime=datetime(2024, 1, 7),
         ExclusionRemarks="Patient has mobility issues",
         IsDeleted="0",
         CreatedDateTime=datetime.now(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,9 +97,9 @@ def sample_activity_exclusion():
 def sample_activity_preference():
     """Create a sample RefActivityPreference instance"""
     return RefActivityPreference(
-        Id=1,
-        PatientId=1,
-        ActivityId=1,
+        CentreActivityPreferenceID=1,
+        PatientID=1,
+        CentreActivityID=1,
         IsLike="1",
         IsDeleted="0",
         CreatedDateTime=datetime.now(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,11 +41,9 @@ def sample_ref_patient():
 def sample_ref_activity():
     """Create a sample RefActivity instance"""
     return RefActivity(
-        Id=1,
+        ActivityID=1,
         ActivityTitle="Morning Exercise",
         ActivityDesc="Light exercise for seniors",
-        StartDate=datetime(2024, 1, 1),
-        EndDate=datetime(2024, 12, 31),
         IsDeleted="0",
         CreatedDateTime=datetime.now(),
         UpdatedDateTime=datetime.now(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from pear_schedule.models.ref_activity_exclusion_model import RefActivityExclusi
 from pear_schedule.models.ref_activity_preference_model import RefActivityPreference
 from pear_schedule.models.ref_activity_recommendation_model import RefActivityRecommendation
 from pear_schedule.models.ref_activity_routine_model import RefActivityRoutine
+from pear_schedule.models.ref_centre_activity_model import RefCentreActivity
 from pear_schedule.models.ref_patient_medication_model import RefPatientMedication
 from pear_schedule.models.schedule_model import Schedule
 
@@ -140,6 +141,28 @@ def sample_activity_routine():
         IsDeleted="0",
         CreatedDateTime=datetime(2024, 2, 27, 0, 54, 33, 981608),
         UpdatedDateTime=datetime(2024, 2, 27, 0, 54, 33, 981609),
+        CreatedById="test_user",
+        ModifiedById="test_user"
+    )
+
+@pytest.fixture
+def sample_centre_activity():
+    """Create a sample RefCentreActivity instance"""
+    return RefCentreActivity(
+        CentreActivityID=1,
+        ActivityID=1,
+        IsDeleted="0",
+        IsCompulsory="0",
+        IsFixed="0",
+        IsGroup="0",
+        StartDate=datetime(2024, 1, 1),
+        EndDate=datetime(2024, 12, 31),
+        MinDuration=30,
+        MaxDuration=60,
+        MinPeopleReq=1,
+        FixedTimeSlots=None,
+        CreatedDateTime=datetime.now(),
+        UpdatedDateTime=datetime.now(),
         CreatedById="test_user",
         ModifiedById="test_user"
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,10 +113,10 @@ def sample_activity_preference():
 def sample_activity_recommendation():
     """Create a sample RefActivityRecommendation instance"""
     return RefActivityRecommendation(
-        Id=1,
-        PatientId=1,
-        ActivityId=1,
-        DoctorId="doc123",
+        CentreActivityRecommendationID=1,
+        PatientID=1,
+        CentreActivityID=1,
+        DoctorID="doc123",
         DoctorRecommendation="1",
         DoctorRemarks="Good for mobility",
         IsDeleted="0",

--- a/tests/unit_tests/test_centre_activity_crud.py
+++ b/tests/unit_tests/test_centre_activity_crud.py
@@ -1,0 +1,522 @@
+import pytest
+from unittest import mock
+from datetime import date, datetime
+
+from pear_schedule.crud.ref_centre_activity_crud import (
+    create_ref_centre_activity,
+    update_ref_centre_activity,
+    delete_ref_centre_activity,
+    get_idempotency_stats,
+    cleanup_old_processed_events,
+    is_event_already_processed
+)
+from pear_schedule.schemas.ref_centre_activity import RefCentreActivityCreate, RefCentreActivityDelete, RefCentreActivityUpdate
+from pear_schedule.services.idempotency_service import IdempotencyService
+
+@pytest.fixture
+def sample_created_ref_centre_activity_data():
+    return RefCentreActivityCreate(
+        CentreActivityID=1,
+        ActivityID=1,
+        IsCompulsory="0",
+        IsFixed="0",
+        IsGroup="0",
+        StartDate="2025-10-10",
+        EndDate="2025-10-13",
+        MinDuration=30,
+        MaxDuration=60,
+        MinPeopleReq=1,
+        FixedTimeSlots=None,
+        IsDeleted="0",
+        CreatedDateTime=datetime.now(),
+        UpdatedDateTime=datetime.now(),
+        CreatedById="test_user",
+        ModifiedById="test_user"
+    )
+@pytest.fixture
+def sample_updated_ref_centre_activity_data():
+    return RefCentreActivityUpdate(
+        ActivityID=10,
+        IsDeleted="0",
+        IsCompulsory="1",
+        IsFixed="1",
+        IsGroup="1",
+        StartDate="2025-10-10",
+        EndDate="2025-11-01",
+        MinDuration=45,
+        MaxDuration=90,
+        MinPeopleReq=5,
+        FixedTimeSlots="09:00-10:00,14:00-15:00",
+        UpdatedDateTime=datetime.now(),
+        ModifiedById="test_user"
+    )
+
+@pytest.fixture
+def sample_deleted_ref_centre_activity_data():
+    return RefCentreActivityDelete(
+        UpdatedDateTime=datetime.now(),
+        ModifiedById="test_user"
+    )
+
+# ==== create_ref_centre_activity tests ====
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.process_idempotent')
+def test_create_ref_centre_activity_success(mock_idempotent_process, db_session_mock, sample_created_ref_centre_activity_data, sample_centre_activity):
+    """Should create a new centre activity successfully"""
+
+    # Mock no existing centre activity found
+    db_session_mock.query().filter().first.side_effect = [None, sample_centre_activity]
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation() # executes create_operation
+        return result, False
+    
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with mock.patch('pear_schedule.crud.ref_centre_activity_crud.RefCentreActivity', return_value=sample_centre_activity):
+        result, was_duplicate = create_ref_centre_activity(
+            db=db_session_mock,
+            centre_activity=sample_created_ref_centre_activity_data,
+            correlation_id="corr_id_123",
+            created_by="test_user"
+        )
+
+        assert result == sample_centre_activity
+        assert was_duplicate is False
+        db_session_mock.flush.assert_called_once()
+        db_session_mock.commit.assert_called_once()
+        mock_idempotent_process.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.record_processed_event')
+def test_create_ref_centre_activity_skip_duplicate_check(mock_records_processed_event, db_session_mock, sample_created_ref_centre_activity_data, sample_centre_activity):
+    """Should create a new centre activity without duplicate check"""
+
+    # Mock no existing centre activity found
+    db_session_mock.query().filter().first.side_effect = [None, sample_centre_activity]
+
+    mock_records_processed_event.return_value = None
+
+    with mock.patch('pear_schedule.crud.ref_centre_activity_crud.RefCentreActivity', return_value=sample_centre_activity):
+        result, was_duplicate = create_ref_centre_activity(
+            db=db_session_mock,
+            centre_activity=sample_created_ref_centre_activity_data,
+            correlation_id="222", 
+            created_by="test_user",
+            skip_duplicate_check=True
+        )
+
+        assert result == sample_centre_activity
+        assert was_duplicate is False
+        db_session_mock.commit.assert_called_once()
+        mock_records_processed_event.assert_called_once()
+    
+def test_create_ref_centre_activity_duplicate_raises(db_session_mock, sample_created_ref_centre_activity_data, sample_centre_activity):
+    """Should raise error when trying to create a duplicate centre activity"""
+
+    # Mock existing centre_activity found
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+
+    with pytest.raises(ValueError):
+        create_ref_centre_activity(
+            db=db_session_mock,
+            centre_activity=sample_created_ref_centre_activity_data,
+            correlation_id="corr_id_789",
+            created_by="test_user"
+        )
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.process_idempotent')
+def test_create_ref_centre_activity_duplicate_detected(mock_idempotent_process, db_session_mock, sample_created_ref_centre_activity_data, sample_centre_activity):
+    """Should return existing record if duplicate detected by idempotency service"""
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+
+    result, was_duplicate = create_ref_centre_activity(
+        db=db_session_mock,
+        centre_activity=sample_created_ref_centre_activity_data,
+        correlation_id="corr_id_101",
+        created_by="test_user"
+    )
+
+    assert was_duplicate is True
+    assert result == sample_centre_activity
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.record_processed_event')
+def test_create_ref_centre_activity_skip_duplicate_check_record_fail(mock_record_processed_event, db_session_mock, sample_created_ref_centre_activity_data, sample_centre_activity):
+    """Skip duplicate check but record_processed_event fails (non-critical)"""
+
+    db_session_mock.query().filter().first.side_effect = [None, sample_centre_activity]
+
+    mock_record_processed_event.side_effect = Exception("DB not reachable")
+
+    with mock.patch('pear_schedule.crud.ref_centre_activity_crud.RefCentreActivity', return_value=sample_centre_activity):
+        result, was_duplicate = create_ref_centre_activity(
+            db=db_session_mock,
+            centre_activity=sample_created_ref_centre_activity_data,
+            correlation_id="corr_skip_fail",
+            created_by="test_user",
+            skip_duplicate_check=True
+        )
+
+    assert result == sample_centre_activity
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+def test_create_ref_centre_activity_creation_fails(db_session_mock, sample_created_ref_centre_activity_data):
+    """Should raise Exception if centre activity creation verification fails"""
+
+    # Both queries return None → simulate failed insert
+    db_session_mock.query().filter().first.side_effect = [None, None]
+
+    with pytest.raises(Exception, match="Failed to create centre activity"):
+        create_ref_centre_activity(
+            db=db_session_mock,
+            centre_activity=sample_created_ref_centre_activity_data,
+            correlation_id="corr_fail_1",
+            created_by="test_user",
+            skip_duplicate_check=True
+        )
+
+# ==== update_ref_centre_activity tests ====
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.process_idempotent')
+def test_update_ref_centre_activity_success(mock_idempotent_process, db_session_mock, sample_updated_ref_centre_activity_data, sample_centre_activity):
+    """Should update an existing centre activity successfully"""
+
+    # Mock existing centre_activity found
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation()
+        return result, False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    result, was_duplicate = update_ref_centre_activity(
+        db=db_session_mock,
+        centre_activity_id=1,
+        centre_activity_update=sample_updated_ref_centre_activity_data,
+        correlation_id="corr_update_123",
+    )
+    assert result == sample_centre_activity
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.process_idempotent')
+def test_update_ref_centre_activity_not_found(mock_idempotent_process, db_session_mock, sample_updated_ref_centre_activity_data):
+    """Should raise error when trying to update a non-existent centre activity"""
+
+    # Mock no existing centre_activity found
+    db_session_mock.query().filter().first.return_value = None
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    result, was_duplicate = update_ref_centre_activity(
+        db=db_session_mock,
+        centre_activity_id=999,
+        centre_activity_update=sample_updated_ref_centre_activity_data,
+        correlation_id="corr_update_999",
+    )
+
+    assert result is None
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.process_idempotent')
+def test_update_ref_centre_activity_duplicate_event(mock_idempotent_process, db_session_mock, sample_updated_ref_centre_activity_data, sample_centre_activity):
+    """Should return existing record if duplicate detected by idempotency service during update"""
+
+    # Mock existing centre_activity found
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = update_ref_centre_activity(
+        db=db_session_mock,
+        centre_activity_id=1,
+        centre_activity_update=sample_updated_ref_centre_activity_data,
+        correlation_id="corr_update_dup",
+    )
+
+    assert was_duplicate is True
+    assert result == sample_centre_activity
+    db_session_mock.commit.assert_not_called()
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.record_processed_event')
+def test_update_ref_centre_activity_skip_duplicate_check(mock_record_processed_event, db_session_mock, sample_updated_ref_centre_activity_data, sample_centre_activity):
+    """Should update an existing centre activity without duplicate check"""
+
+    # Mock existing centre_activity found
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+
+    mock_record_processed_event.return_value = None
+
+    result, was_duplicate = update_ref_centre_activity(
+        db=db_session_mock,
+        centre_activity_id=1,
+        centre_activity_update=sample_updated_ref_centre_activity_data,
+        correlation_id="corr_update_no_dup_check",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_centre_activity
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.record_processed_event')
+def test_update_ref_centre_activity_skip_duplicate_check_record_fail(mock_record_processed_event, db_session_mock, sample_updated_ref_centre_activity_data, sample_centre_activity):
+    """Skip duplicate check but record_processed_event fails (non-critical)"""
+
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+    mock_record_processed_event.side_effect = Exception("DB not reachable")
+
+    result, was_duplicate = update_ref_centre_activity(
+        db=db_session_mock,
+        centre_activity_id=1,
+        centre_activity_update=sample_updated_ref_centre_activity_data,
+        correlation_id="corr_update_skip_fail",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_centre_activity
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.process_idempotent')
+def test_update_ref_centre_activity_error(mock_idempotent_process, db_session_mock, sample_updated_ref_centre_activity_data, sample_centre_activity):
+    """Should handle error during update operation"""
+
+    # Mock existing centre_activity found
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+    db_session_mock.commit.side_effect = Exception("DB not reachable")
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        update_ref_centre_activity(
+            db=db_session_mock,
+            centre_activity_id=1,
+            centre_activity_update=sample_updated_ref_centre_activity_data,
+            correlation_id="corr_update_error",
+        )
+    assert "DB not reachable" in str(exc_info.value)
+    db_session_mock.rollback.assert_called_once()
+
+# ==== delete_ref_centre_activity tests ====
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_centre_activity_success(mock_idempotent_process, db_session_mock, sample_deleted_ref_centre_activity_data, sample_centre_activity):
+    """Should soft delete an existing centre activity successfully"""
+
+    # Mock existing centre_activity found
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation()
+        return result, False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_centre_activity(
+        db=db_session_mock,
+        centre_activity_id=1,
+        centre_activity_delete=sample_deleted_ref_centre_activity_data,
+        correlation_id="corr_delete_123",
+    )
+
+    assert result == sample_centre_activity
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_centre_activity_not_found(mock_idempotent_process, db_session_mock, sample_deleted_ref_centre_activity_data):
+    """Should raise error when trying to delete a non-existent centre activity"""
+
+    # Mock no existing centre_activity found
+    db_session_mock.query().filter().first.return_value = None
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_centre_activity(
+        db=db_session_mock,
+        centre_activity_id=999,
+        centre_activity_delete=sample_deleted_ref_centre_activity_data,
+        correlation_id="corr_delete_999",
+    )
+
+    assert result is None
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_centre_activity_already_deleted(mock_idempotent_process, db_session_mock, sample_deleted_ref_centre_activity_data, sample_centre_activity):
+    """Should handle already deleted centre activity gracefully"""
+
+    # Mock existing centre_activity found and already deleted
+    sample_centre_activity.IsDeleted = "1"
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_centre_activity(
+        db=db_session_mock,
+        centre_activity_id=1,
+        centre_activity_delete=sample_deleted_ref_centre_activity_data,
+        correlation_id="corr_delete_already",
+    )
+
+    assert result == sample_centre_activity
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_centre_activity_duplicate_event(mock_idempotent_process, db_session_mock, sample_deleted_ref_centre_activity_data, sample_centre_activity):
+    """Should return existing record if duplicate detected by idempotency service during delete"""
+
+    # Mock existing centre_activity found
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_centre_activity(
+        db=db_session_mock,
+        centre_activity_id=1,
+        centre_activity_delete=sample_deleted_ref_centre_activity_data,
+        correlation_id="corr_delete_dup",
+    )
+
+    assert was_duplicate is True
+    assert result == sample_centre_activity
+    db_session_mock.commit.assert_not_called()
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.record_processed_event')
+def test_delete_ref_centre_activity_skip_duplicate_check(mock_record_processed_event, db_session_mock, sample_deleted_ref_centre_activity_data, sample_centre_activity):
+    """Should soft delete an existing centre activity without duplicate check"""
+
+    # Mock existing centre_activity found
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+
+    mock_record_processed_event.return_value = None
+
+    result, was_duplicate = delete_ref_centre_activity(
+        db=db_session_mock,
+        centre_activity_id=1,
+        centre_activity_delete=sample_deleted_ref_centre_activity_data,
+        correlation_id="corr_delete_no_dup_check",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_centre_activity
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.record_processed_event')
+def test_delete_ref_centre_activity_skip_duplicate_check_record_fail(mock_record_processed_event, db_session_mock, sample_deleted_ref_centre_activity_data, sample_centre_activity):
+    """Skip duplicate check but record_processed_event fails (non-critical)"""
+
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+    mock_record_processed_event.side_effect = Exception("DB not reachable")
+
+    result, was_duplicate = delete_ref_centre_activity(
+        db=db_session_mock,
+        centre_activity_id=1,
+        centre_activity_delete=sample_deleted_ref_centre_activity_data,
+        correlation_id="corr_delete_skip_fail",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_centre_activity
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_centre_activity_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_centre_activity_error(mock_idempotent_process, db_session_mock, sample_deleted_ref_centre_activity_data, sample_centre_activity):
+    """Should handle error during delete operation"""
+
+    # Mock existing centre_activity found
+    db_session_mock.query().filter().first.return_value = sample_centre_activity
+    db_session_mock.commit.side_effect = Exception("DB not reachable")
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        delete_ref_centre_activity(
+            db=db_session_mock,
+            centre_activity_id=1,
+            centre_activity_delete=sample_deleted_ref_centre_activity_data,
+            correlation_id="corr_delete_error",
+        )
+    assert "DB not reachable" in str(exc_info.value)
+    db_session_mock.rollback.assert_called_once()
+    
+# ===== get_idempotency_stats tests ===
+def test_get_idempotency_stats(db_session_mock):
+    """Test fetching idempotency stats. Makes sure that get_idempotency_stats calls the service and returns its data."""
+    expected_stats = {
+        "total_processed_events": 10,
+        "events_last_24h": 2,
+        "events_with_errors": 1,
+        "events_by_type": [{"event_type": "ACTIVITY_CREATED", "count": 5}],
+        "latest_events": [],
+        "stats_generated_at": "2025-10-12T00:00:00"
+    }
+
+    with mock.patch.object(IdempotencyService, "get_processing_stats", return_value=expected_stats) as mock_get_stats:
+        results = get_idempotency_stats(db=db_session_mock)
+
+        assert results == expected_stats
+        mock_get_stats.assert_called_once_with(db_session_mock)
+
+# ===== cleanup_old_processed_events tests ===
+def test_cleanup_old_processed_events(db_session_mock):
+    """Test cleanup of old processed events. Ensures that cleanup_old_processed_events calls the service method."""
+
+    expected_deleted = 5
+    older_than_days = 60
+    with mock.patch.object(IdempotencyService, "cleanup_old_events", return_value=expected_deleted) as mock_cleanup:
+        result = cleanup_old_processed_events(db=db_session_mock, older_than_days=older_than_days)
+
+        assert result == expected_deleted
+
+        mock_cleanup.assert_called_once_with(db_session_mock, older_than_days)
+
+# ===== is_event_already_processed tests ===
+def test_is_event_already_processed(db_session_mock):
+    """Test checking if event is already processed. Ensures that is_event_already_processed calls the service method."""
+    with mock.patch.object(IdempotencyService, "is_already_processed", return_value=True) as mock_is_processed:
+        result = is_event_already_processed(
+            db=db_session_mock,
+            correlation_id="corr-123",
+        )
+
+        assert result is True
+        mock_is_processed.assert_called_once_with(db_session_mock, "corr-123")

--- a/tests/unit_tests/test_ref_activity_crud.py
+++ b/tests/unit_tests/test_ref_activity_crud.py
@@ -1,192 +1,578 @@
 import pytest
-from unittest.mock import Mock, patch
+from unittest import mock
 from datetime import datetime
+
 from pear_schedule.crud.ref_activity_crud import (
-    create_or_update_ref_activity,
-    update_ref_activity_idempotent,
-    soft_delete_ref_activity_idempotent,
+    create_ref_activity,
+    update_ref_activity,
+    delete_ref_activity,
     get_ref_activities,
-    get_ref_activity_by_id
+    get_ref_activity_by_id,
+    check_activity_exists,
+    get_idempotency_stats,
+    cleanup_old_processed_events,
+    is_event_already_processed
 )
-from pear_schedule.schemas.ref_activity import RefActivityCreate, RefActivityUpdate
+from pear_schedule.schemas.ref_activity import RefActivityCreate, RefActivityUpdate, RefActivityDelete
+from pear_schedule.services.idempotency_service import IdempotencyService
+
+@pytest.fixture
+def sample_updated_ref_data():
+    return RefActivityUpdate(
+        ActivityTitle="Updated Title",
+        ActivityDesc="Updated Desc",
+        IsDeleted=False,
+        UpdatedDateTime=datetime.now(),
+        ModifiedById="test_user"
+    )
+
+@pytest.fixture
+def sample_deleted_ref_data():
+    return RefActivityDelete(
+        ActivityTitle="Deleted Title",
+        ActivityDesc="Deleted Desc",
+        IsDeleted="1",
+        UpdatedDateTime=datetime.now(),
+        ModifiedById="test_user"
+    )
+
+# ==== create_ref_activity tests ===
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_success(mock_idempotency_process, db_session_mock, sample_ref_activity):
+    """Test successful creation of a reference activity."""
+
+    # Mock no existing activity
+    db_session_mock.query().filter().first.side_effect = [None, sample_ref_activity]
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation() # executes create_operation
+        return result, False
+
+    # Mock idempotency service returns not duplicate
+    mock_idempotency_process.side_effect = fake_process_idempotent
+
+    activity_data = RefActivityCreate(
+            ActivityID=1,
+            ActivityTitle="Morning Exercise",
+            ActivityDesc="Light exercise for seniors",
+            IsDeleted="0",
+            CreatedDateTime=datetime.now(),
+            UpdatedDateTime=datetime.now(),
+            CreatedById="test_user",
+            ModifiedById="test_user"
+        )
+
+    result, was_duplicate = create_ref_activity(
+        db=db_session_mock,
+        activity=activity_data,
+        correlation_id="corr-123",
+        created_by="test_user"
+    )
+
+    assert result == sample_ref_activity
+    assert was_duplicate is False
+    db_session_mock.execute.assert_called_once()
+    db_session_mock.flush.assert_called_once()
+    db_session_mock.commit.assert_called_once()
+    mock_idempotency_process.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_existing_raises_valueerror(mock_process_idempotent, db_session_mock, sample_ref_activity):
+    """Test ValueError when activity already exists."""
+    db_session_mock.query().filter().first.return_value = sample_ref_activity
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        # directly call operation() which will raise ValueError inside
+        return operation(), False
+
+    mock_process_idempotent.side_effect = fake_process_idempotent
+
+    activity_data = RefActivityCreate(
+        ActivityID=1,
+        ActivityTitle="Morning Exercise",
+        ActivityDesc="Light exercise for seniors",
+        IsDeleted="0",
+        CreatedDateTime=datetime.now(),
+        UpdatedDateTime=datetime.now(),
+        CreatedById="test_user",
+        ModifiedById="test_user"
+    )
+
+    with pytest.raises(ValueError, match="already exists"):
+        create_ref_activity(
+            db=db_session_mock,
+            activity=activity_data,
+            correlation_id="corr-123",
+            created_by="test_user"
+        )
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_fails_to_fetch_created(mock_process_idempotent, db_session_mock):
+    """Test Exception when created activity not found after insert."""
+    # first query finds nothing (proceed to insert)
+    db_session_mock.query().filter().first.side_effect = [None, None]
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_process_idempotent.side_effect = fake_process_idempotent
+
+    activity_data = RefActivityCreate(
+        ActivityID=99,
+        ActivityTitle="Missing Record",
+        ActivityDesc="Simulate missing",
+        IsDeleted="0",
+        CreatedDateTime=datetime.now(),
+        UpdatedDateTime=datetime.now(),
+        CreatedById="test_user",
+        ModifiedById="test_user"
+    )
+
+    with pytest.raises(Exception, match="Failed to create activity"):
+        create_ref_activity(
+            db=db_session_mock,
+            activity=activity_data,
+            correlation_id="corr-999",
+            created_by="test_user"
+        )
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_duplicate_returns_existing(mock_process_idempotent, db_session_mock, sample_ref_activity):
+    """Test duplicate idempotent event returns existing activity."""
+    # mock idempotent call returns existing + duplicate=True
+    mock_process_idempotent.return_value = (sample_ref_activity, True)
+    db_session_mock.query().filter().first.return_value = sample_ref_activity
+
+    activity_data = RefActivityCreate(
+        ActivityID=1,
+        ActivityTitle="Morning Exercise",
+        ActivityDesc="Light exercise for seniors",
+        IsDeleted="0",
+        CreatedDateTime=datetime.now(),
+        UpdatedDateTime=datetime.now(),
+        CreatedById="test_user",
+        ModifiedById="test_user"
+    )
+
+    result, was_duplicate = create_ref_activity(
+        db=db_session_mock,
+        activity=activity_data,
+        correlation_id="corr-dup",
+        created_by="test_user"
+    )
+
+    assert result == sample_ref_activity
+    assert was_duplicate is True
+
+# ==== update_ref_activity tests ===
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_success(mock_idempotency_process, db_session_mock, sample_ref_activity, sample_updated_ref_data):
+    """Test successful update of a reference activity."""
+    # Mock existing activity found
+    db_session_mock.query().filter().first.return_value = sample_ref_activity
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation() # executes update_operation
+        return result, False
+    mock_idempotency_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = update_ref_activity(
+        db=db_session_mock,
+        activity_id=1,
+        activity_update=sample_updated_ref_data,
+        correlation_id="corr-update-123",
+    )
+
+    assert result == sample_ref_activity
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_not_found(mock_process_idempotent, db_session_mock, sample_updated_ref_data):
+    """Test when activity to update not found."""
+    db_session_mock.query().filter().first.return_value = None
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_process_idempotent.side_effect = fake_process_idempotent
+
+    result, was_duplicate = update_ref_activity(
+        db=db_session_mock,
+        activity_id=999,
+        activity_update=sample_updated_ref_data,
+        correlation_id="corr-update-999",
+    )
+
+    assert result is None
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_duplicate_event(mock_process_idempotent, db_session_mock, sample_ref_activity, sample_updated_ref_data):
+    """Test duplicate idempotent event returns existing activity."""
+    # mock idempotent call returns existing + duplicate=True
+    mock_process_idempotent.return_value = (sample_ref_activity, True)
+    db_session_mock.query().filter().first.return_value = sample_ref_activity
+
+    result, was_duplicate = update_ref_activity(
+        db=db_session_mock,
+        activity_id=1,
+        activity_update=sample_updated_ref_data,
+        correlation_id="corr-update-dup",
+    )
+
+    assert result == sample_ref_activity
+    assert was_duplicate is True
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.record_processed_event')
+def test_update_ref_activity_skip_duplicate_check(mock_record_processed_event, mock_process_idempotent, db_session_mock, sample_ref_activity, sample_updated_ref_data):
+    """Test update when skipping duplicate idempotency check."""
+    # Mock existing activity found
+    db_session_mock.query().filter().first.return_value = sample_ref_activity
+    mock_record_processed_event.return_value = None
+
+    result, was_duplicate = update_ref_activity(
+        db=db_session_mock,
+        activity_id=1,
+        activity_update=sample_updated_ref_data,
+        correlation_id="corr-update-skip",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_ref_activity
+    assert was_duplicate is False
+    mock_process_idempotent.assert_not_called()
+    mock_record_processed_event.assert_called_once()
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.record_processed_event')
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_skip_duplicate_record_fails(mock_process_idempotent, mock_record_processed_event, db_session_mock, sample_ref_activity, sample_updated_ref_data):
+    """Test that a warning is logged if record_processed_event fails while skipping duplicate check."""
+    # Mock existing activity
+    db_session_mock.query().filter().first.return_value = sample_ref_activity
+
+    # Make record_processed_event raise exception
+    mock_record_processed_event.side_effect = Exception("non-critical failure")
+
+    result, was_duplicate = update_ref_activity(
+        db=db_session_mock,
+        activity_id=1,
+        activity_update=sample_updated_ref_data,
+        correlation_id="corr-update-warning",
+        skip_duplicate_check=True
+    )
+
+    # Activity should still be returned correctly
+    assert result == sample_ref_activity
+    assert was_duplicate is False
+    mock_process_idempotent.assert_not_called()
+    mock_record_processed_event.assert_called_once()
+    db_session_mock.commit.assert_called_once()
 
 
-class TestRefActivityCrud:
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_process_raises(mock_process_idempotent, db_session_mock, sample_updated_ref_data):
+    """Test that exceptions in process_idempotent trigger rollback and logger.error."""
+    # Make process_idempotent raise exception
+    mock_process_idempotent.side_effect = Exception("critical failure")
+
+    with pytest.raises(Exception, match="critical failure"):
+        update_ref_activity(
+            db=db_session_mock,
+            activity_id=1,
+            activity_update=sample_updated_ref_data,
+            correlation_id="corr-update-error"
+        )
+
+    db_session_mock.rollback.assert_called_once()
+    db_session_mock.commit.assert_not_called()
+
+# ==== delete_ref_activity tests ===
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_success(mock_idempotency_process, db_session_mock, sample_ref_activity, sample_deleted_ref_data):
+    """Test soft deletion of a reference activity."""
+    # Mock existing activity found
+    db_session_mock.query().filter().first.return_value = sample_ref_activity
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation()
+        return result, False
+    mock_idempotency_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity(
+        db=db_session_mock,
+        activity_id=1,
+        activity_delete=sample_deleted_ref_data,
+        correlation_id="corr-delete-123",
+    )
+
+    assert result == sample_ref_activity
+    assert was_duplicate is False
+    assert sample_ref_activity.IsDeleted == "1"
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_not_exists(mock_process_idempotent, db_session_mock, sample_deleted_ref_data):
+    """Test deletion when activity not found."""
+    db_session_mock.query().filter().first.return_value = None
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_process_idempotent.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity(
+        db=db_session_mock,
+        activity_id=999,
+        activity_delete=sample_deleted_ref_data,
+        correlation_id="corr-delete-999",
+    )
+
+    assert result is None
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_already_deleted(mock_process_idempotent, db_session_mock, sample_ref_activity, sample_deleted_ref_data):
+    """Test deletion when activity is already marked as deleted."""
+    # Mock existing activity already deleted
+    sample_ref_activity.IsDeleted = "1"
+    db_session_mock.query().filter().first.return_value = sample_ref_activity
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_process_idempotent.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity(
+        db=db_session_mock,
+        activity_id=1,
+        activity_delete=sample_deleted_ref_data,
+        correlation_id="corr-delete-already",
+    )
+
+    assert result == sample_ref_activity
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_duplicate_event(mock_process_idempotent, db_session_mock, sample_ref_activity, sample_deleted_ref_data):
+    """Test duplicate idempotent event returns existing activity."""
+    # mock idempotent call returns existing + duplicate=True
+    mock_process_idempotent.return_value = (sample_ref_activity, True)
+    db_session_mock.query().filter().first.return_value = sample_ref_activity
+
+    result, was_duplicate = delete_ref_activity(
+        db=db_session_mock,
+        activity_id=1,
+        activity_delete=sample_deleted_ref_data,
+        correlation_id="corr-delete-dup",
+    )
+
+    assert result == sample_ref_activity
+    assert was_duplicate is True
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.record_processed_event')
+def test_delete_ref_activity_skip_duplicate_check(mock_record_processed_event, mock_process_idempotent, db_session_mock, sample_ref_activity, sample_deleted_ref_data):
+    """Test delete when skipping duplicate idempotency check."""
+    # Mock existing activity found
+    db_session_mock.query().filter().first.return_value = sample_ref_activity
+    mock_record_processed_event.return_value = None
+
+    result, was_duplicate = delete_ref_activity(
+        db=db_session_mock,
+        activity_id=1,
+        activity_delete=sample_deleted_ref_data,
+        correlation_id="corr-delete-skip",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_ref_activity
+    assert was_duplicate is False
+    assert sample_ref_activity.IsDeleted == "1"
+    mock_process_idempotent.assert_not_called()
+    mock_record_processed_event.assert_called_once()
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.record_processed_event')
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_skip_duplicate_record_fails(mock_process_idempotent, mock_record_processed_event, db_session_mock, sample_ref_activity, sample_deleted_ref_data):
+    """Test that a warning is logged if record_processed_event fails while skipping duplicate check."""
+    # Mock existing activity
+    db_session_mock.query().filter().first.return_value = sample_ref_activity
+
+    # Make record_processed_event raise exception
+    mock_record_processed_event.side_effect = Exception("non-critical failure")
+
+    result, was_duplicate = delete_ref_activity(
+        db=db_session_mock,
+        activity_id=1,
+        activity_delete=sample_deleted_ref_data,
+        correlation_id="corr-delete-warning",
+        skip_duplicate_check=True
+    )
+
+    # Activity should still be returned correctly
+    assert result == sample_ref_activity
+    assert was_duplicate is False
+    mock_process_idempotent.assert_not_called()
+    mock_record_processed_event.assert_called_once()
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_process_raises(mock_process_idempotent, db_session_mock, sample_deleted_ref_data):
+    """Test that exceptions in process_idempotent trigger rollback and logger.error."""
+    # Make process_idempotent raise exception
+    mock_process_idempotent.side_effect = Exception("critical failure")
+
+    with pytest.raises(Exception, match="critical failure"):
+        delete_ref_activity(
+            db=db_session_mock,
+            activity_id=1,
+            activity_delete=sample_deleted_ref_data,
+            correlation_id="corr-delete-error"
+        )
+
+    db_session_mock.rollback.assert_called_once()
+    db_session_mock.commit.assert_not_called()
+
+# ==== get_ref_activity_by_id tests ===
+def test_get_ref_activity_by_id_found(db_session_mock, sample_ref_activity):
+    """Test fetching an activity by ID when it exists."""
+    db_session_mock.query().filter().first.return_value = sample_ref_activity
+
+    result = get_ref_activity_by_id(db=db_session_mock, activity_id=1)
+
+    assert result == sample_ref_activity
+    db_session_mock.query().filter().first.assert_called_once()
+
+def test_get_ref_activity_by_id_not_found(db_session_mock):
+    """Test fetching an activity by ID when it does not exist."""
+    db_session_mock.query().filter().first.return_value = None
+
+    result = get_ref_activity_by_id(db=db_session_mock, activity_id=999)
+
+    assert result is None
+    db_session_mock.query().filter().first.assert_called_once()
+
+# ==== get_ref_activities tests ===
+def test_get_ref_activities_no_filters(db_session_mock, sample_ref_activity):
+    """Test fetching all activities with pagination without filters."""
+    db_session_mock.query().filter().all.return_value = [sample_ref_activity]
+
+    count_filter_mock = db_session_mock.query.return_value.filter.return_value
+    count_filter_mock.scalar.return_value = 1
     
-    def test_create_or_update_ref_activity_create_new(self, db_session_mock, sample_ref_activity):
-        """Test creating a new activity when one doesn't exist"""
-        # Mock that no existing activity is found
-        db_session_mock.query().filter().first.side_effect = [None, sample_ref_activity]
-        
-        activity_data = RefActivityCreate(
-            Id=1,
-            Title="Morning Exercise",
-            Desc="Light exercise for seniors",
-            StartDate=datetime(2024, 1, 1),
-            EndDate=datetime(2024, 12, 31),
-            IsDeleted="0",
-            CreatedDateTime=datetime.now(),
-            UpdatedDateTime=datetime.now(),
-            CreatedById="test_user",
-            ModifiedById="test_user"
+    activities, total_records, total_pages = get_ref_activities(
+        db=db_session_mock,
+        page_no=0,
+        page_size=10
+    )
+    
+    assert len(activities) == 1
+    assert activities[0] == sample_ref_activity
+    assert total_records == 1
+    assert total_pages == 1
+
+def test_get_ref_activities_with_title_filter(db_session_mock, sample_ref_activity):
+    """Test fetching activities with title filter."""
+    db_session_mock.query().filter().all.return_value = [sample_ref_activity]
+
+    count_filter_mock = db_session_mock.query.return_value.filter.return_value
+    count_filter_mock.scalar.return_value = 1
+
+    activities, total_records, total_pages = get_ref_activities(
+        db=db_session_mock,
+        title_filter="Morning",
+        page_no=0,
+        page_size=10
+    )
+
+    assert len(activities) == 1
+    assert activities[0] == sample_ref_activity
+    assert total_records == 1
+    assert total_pages == 1
+
+def test_get_ref_activities_pagination(db_session_mock, sample_ref_activity):
+    """Test fetching activities with pagination."""
+    db_session_mock.query().filter().all.return_value = [sample_ref_activity]
+
+    count_filter_mock = db_session_mock.query.return_value.filter.return_value
+    count_filter_mock.scalar.return_value = 35  # Simulate 15 total records
+
+    activities, total_records, total_pages = get_ref_activities(
+        db=db_session_mock,
+        page_no=2,
+        page_size=10
+    )
+
+    assert len(activities) == 1
+    assert activities[0] == sample_ref_activity
+    assert total_records == 35
+    assert total_pages == 4  # 35 records with page size 10 should yield 2 pages
+
+# ===== check_activity_exists tests ===
+def test_check_activity_exists_true(db_session_mock):
+    """Test activity exists returns True."""
+    db_session_mock.query.return_value.filter.return_value.scalar.return_value = 1
+
+    exists = check_activity_exists(db=db_session_mock, activity_id=1)
+
+    assert exists is True
+    db_session_mock.query.return_value.filter.return_value.scalar.assert_called_once()
+
+
+def test_check_activity_exists_false(db_session_mock):
+    """Test activity exists returns False."""
+    db_session_mock.query.return_value.filter.return_value.scalar.return_value = 0
+
+    exists = check_activity_exists(db=db_session_mock, activity_id=999)
+
+    assert exists is False
+    db_session_mock.query.return_value.filter.return_value.scalar.assert_called_once()
+
+# ===== get_idempotency_stats tests ===
+def test_get_idempotency_stats(db_session_mock):
+    """Test fetching idempotency stats. Makes sure that get_idempotency_stats calls the service and returns its data."""
+    expected_stats = {
+        "total_processed_events": 10,
+        "events_last_24h": 2,
+        "events_with_errors": 1,
+        "events_by_type": [{"event_type": "ACTIVITY_CREATED", "count": 5}],
+        "latest_events": [],
+        "stats_generated_at": "2025-10-12T00:00:00"
+    }
+
+    with mock.patch.object(IdempotencyService, "get_processing_stats", return_value=expected_stats) as mock_get_stats:
+        results = get_idempotency_stats(db=db_session_mock)
+
+        assert results == expected_stats
+        mock_get_stats.assert_called_once_with(db_session_mock)
+
+# ===== cleanup_old_processed_events tests ===
+def test_cleanup_old_processed_events(db_session_mock):
+    """Test cleanup of old processed events. Ensures that cleanup_old_processed_events calls the service method."""
+
+    expected_deleted = 5
+    older_than_days = 60
+    with mock.patch.object(IdempotencyService, "cleanup_old_events", return_value=expected_deleted) as mock_cleanup:
+        result = cleanup_old_processed_events(db=db_session_mock, older_than_days=older_than_days)
+
+        assert result == expected_deleted
+
+        mock_cleanup.assert_called_once_with(db_session_mock, older_than_days)
+
+# ===== is_event_already_processed tests ===
+def test_is_event_already_processed(db_session_mock):
+    """Test checking if event is already processed. Ensures that is_event_already_processed calls the service method."""
+    with mock.patch.object(IdempotencyService, "is_already_processed", return_value=True) as mock_is_processed:
+        result = is_event_already_processed(
+            db=db_session_mock,
+            correlation_id="corr-123",
         )
-        
-        with patch('app.crud.ref_activity_crud.text') as mock_text:
-            result = create_or_update_ref_activity(db_session_mock, activity_data, "test_user")
-        
-        db_session_mock.execute.assert_called_once()
-        db_session_mock.commit.assert_called_once()
-        assert result == sample_ref_activity
 
-    def test_create_or_update_ref_activity_update_existing(self, db_session_mock, sample_ref_activity):
-        """Test updating an existing activity"""
-        db_session_mock.query().filter().first.return_value = sample_ref_activity
-        
-        activity_data = RefActivityCreate(
-            Id=1,
-            Title="Updated Exercise",
-            Desc="Updated description",
-            StartDate=datetime(2024, 1, 1),
-            EndDate=datetime(2024, 12, 31),
-            IsDeleted="0",
-            CreatedDateTime=datetime.now(),
-            UpdatedDateTime=datetime.now(),
-            CreatedById="test_user",
-            ModifiedById="test_user"
-        )
-        
-        result = create_or_update_ref_activity(db_session_mock, activity_data, "test_user")
-        
-        db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once_with(sample_ref_activity)
-        assert result == sample_ref_activity
-
-    def test_update_ref_activity_idempotent_activity_exists(self, db_session_mock, sample_ref_activity):
-        """Test updating an activity that exists"""
-        db_session_mock.query().filter().first.return_value = sample_ref_activity
-        
-        update_data = RefActivityUpdate(
-            Id=1,
-            Title="Updated Title",
-            Desc="Updated Description",
-            StartDate=datetime(2024, 1, 1),
-            EndDate=datetime(2024, 12, 31),
-            IsDeleted="0",
-            UpdatedDateTime=datetime.now(),
-            ModifiedById="test_user"
-        )
-        
-        result = update_ref_activity_idempotent(db_session_mock, 1, update_data, "test_user")
-        
-        db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once_with(sample_ref_activity)
-        assert result == sample_ref_activity
-
-    def test_update_ref_activity_idempotent_activity_not_exists(self, db_session_mock):
-        """Test updating an activity that doesn't exist"""
-        db_session_mock.query().filter().first.return_value = None
-        
-        update_data = RefActivityUpdate(
-            Id=1,
-            Title="Updated Title",
-            Desc="Updated Description",
-            StartDate=datetime(2024, 1, 1),
-            EndDate=datetime(2024, 12, 31),
-            IsDeleted="0",
-            UpdatedDateTime=datetime.now(),
-            ModifiedById="test_user"
-        )
-        
-        result = update_ref_activity_idempotent(db_session_mock, 999, update_data, "test_user")
-        
-        assert result is None
-        db_session_mock.commit.assert_not_called()
-
-    def test_soft_delete_ref_activity_idempotent_activity_exists(self, db_session_mock, sample_ref_activity):
-        """Test soft deleting an activity that exists"""
-        db_session_mock.query().filter().first.return_value = sample_ref_activity
-        
-        result = soft_delete_ref_activity_idempotent(db_session_mock, 1, "test_user")
-        
-        assert sample_ref_activity.IsDeleted == "1"
-        db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once_with(sample_ref_activity)
-        assert result == sample_ref_activity
-
-    def test_soft_delete_ref_activity_idempotent_activity_not_exists(self, db_session_mock):
-        """Test soft deleting an activity that doesn't exist"""
-        db_session_mock.query().filter().first.return_value = None
-        
-        result = soft_delete_ref_activity_idempotent(db_session_mock, 999, "test_user")
-        
-        assert result is None
-        db_session_mock.commit.assert_not_called()
-
-    def test_soft_delete_ref_activity_idempotent_already_deleted(self, db_session_mock, sample_ref_activity):
-        """Test soft deleting an activity that's already deleted"""
-        sample_ref_activity.IsDeleted = "1"
-        db_session_mock.query().filter().first.return_value = sample_ref_activity
-        
-        result = soft_delete_ref_activity_idempotent(db_session_mock, 1, "test_user")
-        
-        assert result == sample_ref_activity
-        db_session_mock.commit.assert_not_called()
-
-    def test_get_ref_activities_with_filters(self, db_session_mock, sample_ref_activity):
-        """Test getting activities with title and start_date filters"""
-        db_session_mock.query().filter().filter().filter().order_by().offset().limit().all.return_value = [sample_ref_activity]
-        db_session_mock.query().scalar.return_value = 1
-        
-        activities, total_records, total_pages = get_ref_activities(
-            db_session_mock,
-            pageNo=0,
-            pageSize=10,
-            title="Exercise",
-            start_date=datetime(2024, 1, 1)
-        )
-        
-        assert len(activities) == 1
-        assert activities[0] == sample_ref_activity
-        assert total_records == 1
-        assert total_pages == 1
-
-    def test_get_ref_activities_no_filters(self, db_session_mock, sample_ref_activity):
-        """Test getting activities without filters"""
-        db_session_mock.query().filter().order_by().offset().limit().all.return_value = [sample_ref_activity]
-        db_session_mock.query().scalar.return_value = 1
-        
-        activities, total_records, total_pages = get_ref_activities(db_session_mock)
-        
-        assert len(activities) == 1
-        assert total_records == 1
-        assert total_pages == 1
-
-    def test_get_ref_activity_by_id_found(self, db_session_mock, sample_ref_activity):
-        """Test getting an activity by ID when it exists"""
-        db_session_mock.query().filter().first.return_value = sample_ref_activity
-        
-        result = get_ref_activity_by_id(db_session_mock, 1)
-        
-        assert result == sample_ref_activity
-
-    def test_get_ref_activity_by_id_not_found(self, db_session_mock):
-        """Test getting an activity by ID when it doesn't exist"""
-        db_session_mock.query().filter().first.return_value = None
-        
-        result = get_ref_activity_by_id(db_session_mock, 999)
-        
-        assert result is None
-
-    def test_get_ref_activities_pagination(self, db_session_mock):
-        """Test pagination calculations"""
-        db_session_mock.query().filter().order_by().offset().limit().all.return_value = []
-        db_session_mock.query().scalar.return_value = 35
-        
-        activities, total_records, total_pages = get_ref_activities(
-            db_session_mock,
-            pageNo=2,
-            pageSize=10
-        )
-        
-        assert total_records == 35
-        assert total_pages == 4  # math.ceil(35/10) = 4
+        assert result is True
+        mock_is_processed.assert_called_once_with(db_session_mock, "corr-123")

--- a/tests/unit_tests/test_ref_activity_exclusion_crud.py
+++ b/tests/unit_tests/test_ref_activity_exclusion_crud.py
@@ -1,200 +1,627 @@
 import pytest
-from unittest.mock import Mock, patch
+from unittest import mock
 from datetime import datetime
+
 from pear_schedule.crud.ref_activity_exclusion_crud import (
-    create_or_update_ref_activity_exclusion,
-    update_ref_activity_exclusion_idempotent,
-    soft_delete_ref_activity_exclusion_idempotent,
-    get_ref_activity_exclusions,
-    get_ref_activity_exclusion_by_id,
-    get_exclusions_by_patient_and_activity
+    create_ref_activity_exclusion,
+    update_ref_activity_exclusion,
+    delete_ref_activity_exclusion,
+    get_idempotency_stats,
+    cleanup_old_processed_events,
+    is_event_already_processed
 )
-from pear_schedule.schemas.ref_activity_exclusion import RefActivityExclusionCreate, RefActivityExclusionUpdate
+from pear_schedule.schemas.ref_activity_exclusion import RefActivityExclusionCreate, RefActivityExclusionDelete, RefActivityExclusionUpdate
+from pear_schedule.services.idempotency_service import IdempotencyService
 
+@pytest.fixture
+def sample_created_ref_activity_exclusion_data():
+    return RefActivityExclusionCreate(
+        ActivityExclusionID=1,
+        PatientID=10,
+        ActivityID=5,
+        StartDateTime=datetime.now(),
+        EndDateTime=datetime.now(),
+        ExclusionRemarks="Initial Remarks",
+        IsDeleted="0",
+        CreatedDateTime=datetime.now(),
+        UpdatedDateTime=datetime.now(),
+        CreatedById="test_user",
+        ModifiedById="test_user"
+    )
+@pytest.fixture
+def sample_updated_ref_activitiy_exclusion_data():
+    return RefActivityExclusionUpdate(
+        PatientID=20,
+        ActivityID=10,
+        IsDeleted="0",
+        StartDateTime=datetime.now(),
+        EndDateTime=datetime.now(),
+        ExclusionRemarks="Updated Remarks",
+        UpdatedDateTime=datetime.now(),
+        ModifiedById="test_user"
+    )
 
-class TestRefActivityExclusionCrud:
+@pytest.fixture
+def sample_deleted_ref_activity_exclusion_data():
+    return RefActivityExclusionDelete(
+        UpdatedDateTime=datetime.now(),
+        ModifiedById="test_user"
+    )
+
+# ==== create_ref_activity_exclusion tests ====
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_exclusion_success(mock_idempotent_process, db_session_mock, sample_created_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Should create a new activity exclusion successfully"""
+
+    # Mock no existing exclusion found
+    db_session_mock.query().filter().first.side_effect = [None, sample_activity_exclusion]
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation() # executes create_operation
+        return result, False
     
-    def test_create_or_update_ref_activity_exclusion_create_new(self, db_session_mock, sample_activity_exclusion):
-        """Test creating a new activity exclusion when one doesn't exist"""
-        # Mock that no existing exclusion is found
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.first.return_value = None
-        
-        exclusion_data = RefActivityExclusionCreate(
-            PatientId=1,
-            ActivityId=1,
-            StartDate=datetime(2024, 1, 1),
-            EndDate=datetime(2024, 1, 7),
-            ExclusionRemarks="Patient has mobility issues",
-            IsDeleted="0",
-            CreatedDateTime=datetime.now(),
-            UpdatedDateTime=datetime.now(),
-            CreatedById="test_user",
-            ModifiedById="test_user"
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.RefActivityExclusion', return_value=sample_activity_exclusion):
+        result, was_duplicate = create_ref_activity_exclusion(
+            db=db_session_mock,
+            exclusion=sample_created_ref_activity_exclusion_data,
+            correlation_id="corr_id_123",
+            created_by="test_user"
         )
-        
-        # Mock refresh to set the Id after creation
-        def mock_refresh(obj):
-            obj.Id = 1
-        db_session_mock.refresh.side_effect = mock_refresh
-        
-        result = create_or_update_ref_activity_exclusion(db_session_mock, exclusion_data, "test_user")
-        
+
+        assert result == sample_activity_exclusion
+        assert was_duplicate is False
+        db_session_mock.add.assert_called_once()
+        db_session_mock.flush.assert_called_once()
+        db_session_mock.commit.assert_called_once()
+        mock_idempotent_process.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.record_processed_event')
+def test_create_ref_activity_exclusion_skip_duplicate_check(mock_records_processed_event, db_session_mock, sample_created_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Should create a new activity exclusion without duplicate check"""
+
+    # Mock no existing exclusion found
+    db_session_mock.query().filter().first.return_value = None
+    mock_records_processed_event.return_value = None
+
+    with mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.RefActivityExclusion', return_value=sample_activity_exclusion):
+        result, was_duplicate = create_ref_activity_exclusion(
+            db=db_session_mock,
+            exclusion=sample_created_ref_activity_exclusion_data,
+            correlation_id="222", 
+            created_by="test_user",
+            skip_duplicate_check=True
+        )
+
+        assert result == sample_activity_exclusion
+        assert was_duplicate is False
         db_session_mock.add.assert_called_once()
         db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once()
+        mock_records_processed_event.assert_called_once()
+    
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_exclusion_reactivate_soft_deleted(mock_idempotent_process, db_session_mock, sample_created_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Should reactivate a soft-deleted activity exclusion"""
 
-    def test_create_or_update_ref_activity_exclusion_update_existing(self, db_session_mock, sample_activity_exclusion):
-        """Test updating an existing activity exclusion"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.first.return_value = sample_activity_exclusion
-        
-        exclusion_data = RefActivityExclusionCreate(
-            PatientId=1,
-            ActivityId=1,
-            StartDate=datetime(2024, 1, 1),
-            EndDate=datetime(2024, 1, 14),
-            ExclusionRemarks="Updated remarks",
-            IsDeleted="0",
-            CreatedDateTime=datetime.now(),
-            UpdatedDateTime=datetime.now(),
-            CreatedById="test_user",
-            ModifiedById="test_user"
+    # Mock existing soft-deleted exclusion found
+    soft_deleted_exclusion = sample_activity_exclusion
+    soft_deleted_exclusion.IsDeleted = "1"
+    db_session_mock.query().filter().first.side_effect = [soft_deleted_exclusion, soft_deleted_exclusion]
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation()
+        return result, False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    with mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.RefActivityExclusion', return_value=soft_deleted_exclusion):
+        result, was_duplicate = create_ref_activity_exclusion(
+            db=db_session_mock,
+            exclusion=sample_created_ref_activity_exclusion_data,
+            correlation_id="corr_id_456",
+            created_by="test_user"
         )
-        
-        result = create_or_update_ref_activity_exclusion(db_session_mock, exclusion_data, "test_user")
-        
+
+        assert result == soft_deleted_exclusion
+        assert result.IsDeleted == "0"
+        assert was_duplicate is False
         db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once_with(sample_activity_exclusion)
-        assert result == sample_activity_exclusion
 
-    def test_update_ref_activity_exclusion_idempotent_exists(self, db_session_mock, sample_activity_exclusion):
-        """Test updating an activity exclusion that exists"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = sample_activity_exclusion
-        
-        update_data = RefActivityExclusionUpdate(
-            PatientId=1,
-            ActivityId=1,
-            StartDate=datetime(2024, 1, 1),
-            EndDate=datetime(2024, 1, 14),
-            ExclusionRemarks="Updated exclusion remarks",
-            IsDeleted="0",
-            UpdatedDateTime=datetime.now(),
-            ModifiedById="test_user"
+def test_create_ref_activity_exclusion_duplicate_raises(db_session_mock, sample_created_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Should raise error when trying to create a duplicate activity exclusion"""
+
+    # Mock existing exclusion found
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+
+    with pytest.raises(ValueError):
+        create_ref_activity_exclusion(
+            db=db_session_mock,
+            exclusion=sample_created_ref_activity_exclusion_data,
+            correlation_id="corr_id_789",
+            created_by="test_user"
         )
-        
-        result = update_ref_activity_exclusion_idempotent(db_session_mock, 1, update_data, "test_user")
-        
-        db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once_with(sample_activity_exclusion)
-        assert result == sample_activity_exclusion
 
-    def test_update_ref_activity_exclusion_idempotent_not_exists(self, db_session_mock):
-        """Test updating an activity exclusion that doesn't exist"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = None
-        
-        update_data = RefActivityExclusionUpdate(
-            PatientId=1,
-            ActivityId=1,
-            StartDate=datetime(2024, 1, 1),
-            EndDate=datetime(2024, 1, 14),
-            ExclusionRemarks="Updated exclusion remarks",
-            IsDeleted="0",
-            UpdatedDateTime=datetime.now(),
-            ModifiedById="test_user"
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_exclusion_duplicate_detected(mock_idempotent_process, db_session_mock, sample_created_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Should return existing record if duplicate detected by idempotency service"""
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+
+    result, was_duplicate = create_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion=sample_created_ref_activity_exclusion_data,
+        correlation_id="corr_id_101",
+        created_by="test_user"
+    )
+
+    assert was_duplicate is True
+    assert result == sample_activity_exclusion
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_exclusion_foreign_key_patient_error(mock_idempotent_process, db_session_mock, sample_created_ref_activity_exclusion_data):
+    """Should raise foreign key error for invalid PatientID"""
+
+    # Mock no existing exclusion found
+    db_session_mock.query().filter().first.return_value = None
+    db_session_mock.add.side_effect = Exception("FOREIGN KEY constraint failed: REF_PATIENT")
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        create_ref_activity_exclusion(
+            db=db_session_mock,
+            exclusion=sample_created_ref_activity_exclusion_data,
+            correlation_id="corr_id_102",
+            created_by="test_user"
         )
-        
-        result = update_ref_activity_exclusion_idempotent(db_session_mock, 999, update_data, "test_user")
-        
-        assert result is None
-        db_session_mock.commit.assert_not_called()
+    assert "foreign key" in str(exc_info.value).lower()
+    db_session_mock.rollback.assert_called_once()
 
-    def test_soft_delete_ref_activity_exclusion_idempotent_exists(self, db_session_mock, sample_activity_exclusion):
-        """Test soft deleting an activity exclusion that exists"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = sample_activity_exclusion
-        
-        result = soft_delete_ref_activity_exclusion_idempotent(db_session_mock, 1, "test_user")
-        
-        assert sample_activity_exclusion.IsDeleted == "1"
-        db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once_with(sample_activity_exclusion)
-        assert result == sample_activity_exclusion
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_exclusion_foreign_key_activity_error(mock_idempotent_process, db_session_mock, sample_created_ref_activity_exclusion_data):
+    """Should raise foreign key error for invalid ActivityID"""
 
-    def test_soft_delete_ref_activity_exclusion_idempotent_not_exists(self, db_session_mock):
-        """Test soft deleting an activity exclusion that doesn't exist"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = None
-        
-        result = soft_delete_ref_activity_exclusion_idempotent(db_session_mock, 999, "test_user")
-        
-        assert result is None
-        db_session_mock.commit.assert_not_called()
+    # Mock no existing exclusion found
+    db_session_mock.query().filter().first.return_value = None
+    db_session_mock.add.side_effect = Exception("FOREIGN KEY constraint failed: REF_ACTIVITY")
 
-    def test_soft_delete_ref_activity_exclusion_idempotent_already_deleted(self, db_session_mock, sample_activity_exclusion):
-        """Test soft deleting an activity exclusion that's already deleted"""
-        sample_activity_exclusion.IsDeleted = "1"
-        db_session_mock.query.return_value.filter.return_value.first.return_value = sample_activity_exclusion
-        
-        result = soft_delete_ref_activity_exclusion_idempotent(db_session_mock, 1, "test_user")
-        
-        assert result == sample_activity_exclusion
-        db_session_mock.commit.assert_not_called()
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
 
-    def test_get_ref_activity_exclusions_with_filters(self, db_session_mock, sample_activity_exclusion):
-        """Test getting activity exclusions with patient_id and activity_id filters"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = [sample_activity_exclusion]
-        db_session_mock.query.return_value.scalar.return_value = 1
-        
-        exclusions, total_records, total_pages = get_ref_activity_exclusions(
-            db_session_mock,
-            pageNo=0,
-            pageSize=10,
-            patient_id=1,
-            activity_id=1
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        create_ref_activity_exclusion(
+            db=db_session_mock,
+            exclusion=sample_created_ref_activity_exclusion_data,
+            correlation_id="corr_id_102",
+            created_by="test_user"
         )
-        
-        assert len(exclusions) == 1
-        assert exclusions[0] == sample_activity_exclusion
-        assert total_records == 1
-        assert total_pages == 1
+    assert "foreign key" in str(exc_info.value).lower()
+    db_session_mock.rollback.assert_called_once()
 
-    def test_get_ref_activity_exclusions_no_filters(self, db_session_mock, sample_activity_exclusion):
-        """Test getting activity exclusions without filters"""
-        db_session_mock.query.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = [sample_activity_exclusion]
-        db_session_mock.query.return_value.scalar.return_value = 1
-        
-        exclusions, total_records, total_pages = get_ref_activity_exclusions(db_session_mock)
-        
-        assert len(exclusions) == 1
-        assert total_records == 1
-        assert total_pages == 1
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_exclusion_update_existing_active(mock_idempotent_process, db_session_mock, sample_created_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Should raise error when trying to create an exclusion that already exists as active"""
 
-    def test_get_ref_activity_exclusion_by_id_found(self, db_session_mock, sample_activity_exclusion):
-        """Test getting an activity exclusion by ID when it exists"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = sample_activity_exclusion
-        
-        result = get_ref_activity_exclusion_by_id(db_session_mock, 1)
-        
-        assert result == sample_activity_exclusion
+    # Mock existing active exclusion found
+    sample_created_ref_activity_exclusion_data.ActivityExclusionID = None
+    sample_activity_exclusion.IsDeleted = "0"
 
-    def test_get_ref_activity_exclusion_by_id_not_found(self, db_session_mock):
-        """Test getting an activity exclusion by ID when it doesn't exist"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = None
-        
-        result = get_ref_activity_exclusion_by_id(db_session_mock, 999)
-        
-        assert result is None
+    # Mock query to return existing active exclusion
+    db_session_mock.query().filter().first.side_effect = [sample_activity_exclusion]
 
-    def test_get_exclusions_by_patient_and_activity_found(self, db_session_mock, sample_activity_exclusion):
-        """Test getting exclusions for a specific patient and activity"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [sample_activity_exclusion]
-        
-        result = get_exclusions_by_patient_and_activity(db_session_mock, 1, 1)
-        
-        assert len(result) == 1
-        assert result[0] == sample_activity_exclusion
+    def fake_process(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
 
-    def test_get_exclusions_by_patient_and_activity_not_found(self, db_session_mock):
-        """Test getting exclusions for a specific patient and activity when none exist"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = []
-        
-        result = get_exclusions_by_patient_and_activity(db_session_mock, 999, 999)
-        
-        assert len(result) == 0
+    mock_idempotent_process.side_effect = fake_process
+
+    result, was_duplicate = create_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion=sample_created_ref_activity_exclusion_data,
+        correlation_id="corr_id_update_active",
+        created_by="test_user"
+    )
+
+    assert result == sample_activity_exclusion
+    assert result.ExclusionRemarks == sample_created_ref_activity_exclusion_data.ExclusionRemarks
+    assert was_duplicate is False
+    db_session_mock.flush.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.record_processed_event')
+def test_create_ref_activity_exclusion_skip_duplicate_check_record_fail(mock_record_processed_event, db_session_mock, sample_created_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Skip duplicate check but record_processed_event fails (non-critical)"""
+
+    db_session_mock.query().filter().first.return_value = None
+    mock_record_processed_event.side_effect = Exception("DB not reachable")
+
+    with mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.RefActivityExclusion', return_value=sample_activity_exclusion):
+        result, was_duplicate = create_ref_activity_exclusion(
+            db=db_session_mock,
+            exclusion=sample_created_ref_activity_exclusion_data,
+            correlation_id="corr_skip_fail",
+            created_by="test_user",
+            skip_duplicate_check=True
+        )
+
+    assert result == sample_activity_exclusion
+    assert was_duplicate is False
+    db_session_mock.add.assert_called_once()
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_exclusion_duplicate_no_id(mock_idempotent_process, db_session_mock, sample_created_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Covers else branch of was_duplicate handling when ActivityExclusionID is None"""
+
+    # Remove ActivityExclusionID to trigger else branch
+    sample_created_ref_activity_exclusion_data.ActivityExclusionID = None
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True  # was_duplicate=True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    # Mock existing record returned by else-branch query
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+
+    result, was_duplicate = create_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion=sample_created_ref_activity_exclusion_data,
+        correlation_id="corr_no_id_dup",
+        created_by="test_user"
+    )
+
+    assert was_duplicate is True
+    assert result == sample_activity_exclusion
+
+# ==== update_ref_activity_exclusion tests ====
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_exclusion_success(mock_idempotent_process, db_session_mock, sample_updated_ref_activitiy_exclusion_data, sample_activity_exclusion):
+    """Should update an existing activity exclusion successfully"""
+
+    # Mock existing exclusion found
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation()
+        return result, False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    result, was_duplicate = update_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion_id=1,
+        exclusion_update=sample_updated_ref_activitiy_exclusion_data,
+        correlation_id="corr_update_123",
+    )
+    assert result == sample_activity_exclusion
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_exclusion_not_found(mock_idempotent_process, db_session_mock, sample_updated_ref_activitiy_exclusion_data):
+    """Should raise error when trying to update a non-existent activity exclusion"""
+
+    # Mock no existing exclusion found
+    db_session_mock.query().filter().first.return_value = None
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    result, was_duplicate = update_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion_id=999,
+        exclusion_update=sample_updated_ref_activitiy_exclusion_data,
+        correlation_id="corr_update_999",
+    )
+
+    assert result is None
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_exclusion_duplicate_event(mock_idempotent_process, db_session_mock, sample_updated_ref_activitiy_exclusion_data, sample_activity_exclusion):
+    """Should return existing record if duplicate detected by idempotency service during update"""
+
+    # Mock existing exclusion found
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = update_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion_id=1,
+        exclusion_update=sample_updated_ref_activitiy_exclusion_data,
+        correlation_id="corr_update_dup",
+    )
+
+    assert was_duplicate is True
+    assert result == sample_activity_exclusion
+    db_session_mock.commit.assert_not_called()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.record_processed_event')
+def test_update_ref_activity_exclusion_skip_duplicate_check(mock_record_processed_event, db_session_mock, sample_updated_ref_activitiy_exclusion_data, sample_activity_exclusion):
+    """Should update an existing activity exclusion without duplicate check"""
+
+    # Mock existing exclusion found
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+
+    mock_record_processed_event.return_value = None
+
+    result, was_duplicate = update_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion_id=1,
+        exclusion_update=sample_updated_ref_activitiy_exclusion_data,
+        correlation_id="corr_update_no_dup_check",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_activity_exclusion
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.record_processed_event')
+def test_update_ref_activity_exclusion_skip_duplicate_check_record_fail(mock_record_processed_event, db_session_mock, sample_updated_ref_activitiy_exclusion_data, sample_activity_exclusion):
+    """Skip duplicate check but record_processed_event fails (non-critical)"""
+
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+    mock_record_processed_event.side_effect = Exception("DB not reachable")
+
+    result, was_duplicate = update_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion_id=1,
+        exclusion_update=sample_updated_ref_activitiy_exclusion_data,
+        correlation_id="corr_update_skip_fail",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_activity_exclusion
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_exclusion_error(mock_idempotent_process, db_session_mock, sample_updated_ref_activitiy_exclusion_data, sample_activity_exclusion):
+    """Should handle error during update operation"""
+
+    # Mock existing exclusion found
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+    db_session_mock.commit.side_effect = Exception("DB not reachable")
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        update_ref_activity_exclusion(
+            db=db_session_mock,
+            exclusion_id=1,
+            exclusion_update=sample_updated_ref_activitiy_exclusion_data,
+            correlation_id="corr_update_error",
+        )
+    assert "DB not reachable" in str(exc_info.value)
+    db_session_mock.rollback.assert_called_once()
+
+# ==== delete_ref_activity_exclusion tests ====
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_exclusion_success(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Should soft delete an existing activity exclusion successfully"""
+
+    # Mock existing exclusion found
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation()
+        return result, False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion_id=1,
+        exclusion_delete=sample_deleted_ref_activity_exclusion_data,
+        correlation_id="corr_delete_123",
+    )
+
+    assert result == sample_activity_exclusion
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_exclusion_not_found(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_exclusion_data):
+    """Should raise error when trying to delete a non-existent activity exclusion"""
+
+    # Mock no existing exclusion found
+    db_session_mock.query().filter().first.return_value = None
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion_id=999,
+        exclusion_delete=sample_deleted_ref_activity_exclusion_data,
+        correlation_id="corr_delete_999",
+    )
+
+    assert result is None
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_exclusion_already_deleted(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Should handle already deleted activity exclusion gracefully"""
+
+    # Mock existing exclusion found and already deleted
+    sample_activity_exclusion.IsDeleted = "1"
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion_id=1,
+        exclusion_delete=sample_deleted_ref_activity_exclusion_data,
+        correlation_id="corr_delete_already",
+    )
+
+    assert result == sample_activity_exclusion
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_exclusion_duplicate_event(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Should return existing record if duplicate detected by idempotency service during delete"""
+
+    # Mock existing exclusion found
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion_id=1,
+        exclusion_delete=sample_deleted_ref_activity_exclusion_data,
+        correlation_id="corr_delete_dup",
+    )
+
+    assert was_duplicate is True
+    assert result == sample_activity_exclusion
+    db_session_mock.commit.assert_not_called()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.record_processed_event')
+def test_delete_ref_activity_exclusion_skip_duplicate_check(mock_record_processed_event, db_session_mock, sample_deleted_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Should soft delete an existing activity exclusion without duplicate check"""
+
+    # Mock existing exclusion found
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+
+    mock_record_processed_event.return_value = None
+
+    result, was_duplicate = delete_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion_id=1,
+        exclusion_delete=sample_deleted_ref_activity_exclusion_data,
+        correlation_id="corr_delete_no_dup_check",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_activity_exclusion
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.record_processed_event')
+def test_delete_ref_activity_exclusion_skip_duplicate_check_record_fail(mock_record_processed_event, db_session_mock, sample_deleted_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Skip duplicate check but record_processed_event fails (non-critical)"""
+
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+    mock_record_processed_event.side_effect = Exception("DB not reachable")
+
+    result, was_duplicate = delete_ref_activity_exclusion(
+        db=db_session_mock,
+        exclusion_id=1,
+        exclusion_delete=sample_deleted_ref_activity_exclusion_data,
+        correlation_id="corr_delete_skip_fail",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_activity_exclusion
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_exclusion_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_exclusion_error(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_exclusion_data, sample_activity_exclusion):
+    """Should handle error during delete operation"""
+
+    # Mock existing exclusion found
+    db_session_mock.query().filter().first.return_value = sample_activity_exclusion
+    db_session_mock.commit.side_effect = Exception("DB not reachable")
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        delete_ref_activity_exclusion(
+            db=db_session_mock,
+            exclusion_id=1,
+            exclusion_delete=sample_deleted_ref_activity_exclusion_data,
+            correlation_id="corr_delete_error",
+        )
+    assert "DB not reachable" in str(exc_info.value)
+    db_session_mock.rollback.assert_called_once()
+    
+# ===== get_idempotency_stats tests ===
+def test_get_idempotency_stats(db_session_mock):
+    """Test fetching idempotency stats. Makes sure that get_idempotency_stats calls the service and returns its data."""
+    expected_stats = {
+        "total_processed_events": 10,
+        "events_last_24h": 2,
+        "events_with_errors": 1,
+        "events_by_type": [{"event_type": "ACTIVITY_CREATED", "count": 5}],
+        "latest_events": [],
+        "stats_generated_at": "2025-10-12T00:00:00"
+    }
+
+    with mock.patch.object(IdempotencyService, "get_processing_stats", return_value=expected_stats) as mock_get_stats:
+        results = get_idempotency_stats(db=db_session_mock)
+
+        assert results == expected_stats
+        mock_get_stats.assert_called_once_with(db_session_mock)
+
+# ===== cleanup_old_processed_events tests ===
+def test_cleanup_old_processed_events(db_session_mock):
+    """Test cleanup of old processed events. Ensures that cleanup_old_processed_events calls the service method."""
+
+    expected_deleted = 5
+    older_than_days = 60
+    with mock.patch.object(IdempotencyService, "cleanup_old_events", return_value=expected_deleted) as mock_cleanup:
+        result = cleanup_old_processed_events(db=db_session_mock, older_than_days=older_than_days)
+
+        assert result == expected_deleted
+
+        mock_cleanup.assert_called_once_with(db_session_mock, older_than_days)
+
+# ===== is_event_already_processed tests ===
+def test_is_event_already_processed(db_session_mock):
+    """Test checking if event is already processed. Ensures that is_event_already_processed calls the service method."""
+    with mock.patch.object(IdempotencyService, "is_already_processed", return_value=True) as mock_is_processed:
+        result = is_event_already_processed(
+            db=db_session_mock,
+            correlation_id="corr-123",
+        )
+
+        assert result is True
+        mock_is_processed.assert_called_once_with(db_session_mock, "corr-123")

--- a/tests/unit_tests/test_ref_activity_preference_crud.py
+++ b/tests/unit_tests/test_ref_activity_preference_crud.py
@@ -1,160 +1,623 @@
 import pytest
-from unittest.mock import Mock, patch
+from unittest import mock
 from datetime import datetime
+
 from pear_schedule.crud.ref_activity_preference_crud import (
-    create_or_update_ref_activity_preference,
-    update_ref_activity_preference_idempotent,
-    soft_delete_ref_activity_preference_idempotent,
-    get_ref_activity_preferences,
-    get_ref_activity_preference_by_id,
-    get_preferences_by_patient_and_activity,
-    get_patient_liked_activities,
-    get_patient_disliked_activities
+    create_ref_activity_preference,
+    update_ref_activity_preference,
+    delete_ref_activity_preference,
+    get_idempotency_stats,
+    cleanup_old_processed_events,
+    is_event_already_processed
 )
-from pear_schedule.schemas.ref_activity_preference import RefActivityPreferenceCreate, RefActivityPreferenceUpdate
 
+from pear_schedule.schemas.ref_activity_preference import RefActivityPreferenceCreate, RefActivityPreferenceUpdate, RefActivityPreferenceDelete
+from pear_schedule.services.idempotency_service import IdempotencyService
 
-class TestRefActivityPreferenceCrud:
+@pytest.fixture
+def sample_created_ref_activity_preference_data():
+    return RefActivityPreferenceCreate(
+        PatientID= 1,
+        CentreActivityID=1,
+        IsLike="0",
+        IsDeleted="0",
+        CentreActivityPreferenceID=1,
+        CreatedDateTime=datetime(2025, 1, 1, 10, 0, 0),
+        UpdatedDateTime=datetime(2025, 1, 1, 10, 0, 0),
+        CreatedById="test_user",
+        ModifiedById="test_user"
+    )
+
+@pytest.fixture
+def sample_updated_ref_activitiy_preference_data():
+    return RefActivityPreferenceUpdate(
+        PatientId=1,
+        ActivityId=1,
+        IsDeleted=False,
+        IsLike="1",
+        UpdatedDateTime=datetime(2025, 1, 2, 10, 0, 0),
+        ModifiedById="test_user"
+    )
+
+@pytest.fixture
+def sample_deleted_ref_activity_preference_data():
+    return RefActivityPreferenceDelete(
+        UpdatedDateTime=datetime(2025, 1, 3, 10, 0, 0),
+        ModifiedById="test_user"
+    )
+
+# ===== create_ref_activity_preference tests ===
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_preference_success(mock_idempotent_process, db_session_mock, sample_created_ref_activity_preference_data, sample_activity_preference):
+    """Should create a new activity preference successfully"""
+
+    # Mock no existing preference found
+    db_session_mock.query().filter().first.side_effect = [None, sample_activity_preference]
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation() # executes create_operation
+        return result, False
     
-    def test_create_or_update_ref_activity_preference_create_new(self, db_session_mock, sample_activity_preference):
-        """Test creating a new activity preference when one doesn't exist"""
-        # Mock that no existing preference is found
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.first.return_value = None
-        
-        preference_data = RefActivityPreferenceCreate(
-            PatientId=1,
-            ActivityId=1,
-            IsLike="1",
-            IsDeleted="0",
-            CreatedDateTime=datetime.now(),
-            UpdatedDateTime=datetime.now(),
-            CreatedById="test_user",
-            ModifiedById="test_user"
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with mock.patch('pear_schedule.crud.ref_activity_preference_crud.RefActivityPreference', return_value=sample_activity_preference):
+        result, was_duplicate = create_ref_activity_preference(
+            db=db_session_mock,
+            preference=sample_created_ref_activity_preference_data,
+            correlation_id="corr_id_123",
+            created_by="test_user"
         )
-        
-        # Mock refresh to set the Id after creation
-        def mock_refresh(obj):
-            obj.Id = 1
-        db_session_mock.refresh.side_effect = mock_refresh
-        
-        result = create_or_update_ref_activity_preference(db_session_mock, preference_data, "test_user")
-        
+
+        assert result == sample_activity_preference
+        assert was_duplicate is False
+        db_session_mock.add.assert_called_once()
+        db_session_mock.flush.assert_called_once()
+        db_session_mock.commit.assert_called_once()
+        mock_idempotent_process.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.record_processed_event')
+def test_create_ref_activity_preference_skip_duplicate_check(mock_records_processed_event, db_session_mock, sample_created_ref_activity_preference_data, sample_activity_preference):
+    """Should create a new activity preference without duplicate check"""
+
+    # Mock no existing preference found
+    db_session_mock.query().filter().first.return_value = None
+    mock_records_processed_event.return_value = None
+
+    with mock.patch('pear_schedule.crud.ref_activity_preference_crud.RefActivityPreference', return_value=sample_activity_preference):
+        result, was_duplicate = create_ref_activity_preference(
+            db=db_session_mock,
+            preference=sample_created_ref_activity_preference_data,
+            correlation_id="222", 
+            created_by="test_user",
+            skip_duplicate_check=True
+        )
+
+        assert result == sample_activity_preference
+        assert was_duplicate is False
         db_session_mock.add.assert_called_once()
         db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once()
+        mock_records_processed_event.assert_called_once()
+    
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_preference_reactivate_soft_deleted(mock_idempotent_process, db_session_mock, sample_created_ref_activity_preference_data, sample_activity_preference):
+    """Should reactivate a soft-deleted activity preference"""
 
-    def test_create_or_update_ref_activity_preference_update_existing(self, db_session_mock, sample_activity_preference):
-        """Test updating an existing activity preference"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.first.return_value = sample_activity_preference
-        
-        preference_data = RefActivityPreferenceCreate(
-            PatientId=1,
-            ActivityId=1,
-            IsLike="0",  # Changed from like to dislike
-            IsDeleted="0",
-            CreatedDateTime=datetime.now(),
-            UpdatedDateTime=datetime.now(),
-            CreatedById="test_user",
-            ModifiedById="test_user"
+    # Mock existing soft-deleted preference found
+    soft_deleted_preference = sample_activity_preference
+    soft_deleted_preference.IsDeleted = "1"
+    db_session_mock.query().filter().first.side_effect = [soft_deleted_preference, soft_deleted_preference]
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation()
+        return result, False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    with mock.patch('pear_schedule.crud.ref_activity_preference_crud.RefActivityPreference', return_value=soft_deleted_preference):
+        result, was_duplicate = create_ref_activity_preference(
+            db=db_session_mock,
+            preference=sample_created_ref_activity_preference_data,
+            correlation_id="corr_id_456",
+            created_by="test_user"
         )
-        
-        result = create_or_update_ref_activity_preference(db_session_mock, preference_data, "test_user")
-        
+
+        assert result == soft_deleted_preference
+        assert result.IsDeleted == "0"
+        assert was_duplicate is False
         db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once_with(sample_activity_preference)
-        assert result == sample_activity_preference
 
-    def test_update_ref_activity_preference_idempotent_exists(self, db_session_mock, sample_activity_preference):
-        """Test updating an activity preference that exists"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = sample_activity_preference
-        
-        update_data = RefActivityPreferenceUpdate(
-            PatientId=1,
-            ActivityId=1,
-            IsLike="0",
-            IsDeleted="0",
-            UpdatedDateTime=datetime.now(),
-            ModifiedById="test_user"
+def test_create_ref_activity_preference_duplicate_raises(db_session_mock, sample_created_ref_activity_preference_data, sample_activity_preference):
+    """Should raise error when trying to create a duplicate activity preference"""
+
+    # Mock existing preference found
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+
+    with pytest.raises(ValueError):
+        create_ref_activity_preference(
+            db=db_session_mock,
+            preference=sample_created_ref_activity_preference_data,
+            correlation_id="corr_id_789",
+            created_by="test_user"
         )
-        
-        result = update_ref_activity_preference_idempotent(db_session_mock, 1, update_data, "test_user")
-        
-        db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once_with(sample_activity_preference)
-        assert result == sample_activity_preference
 
-    def test_update_ref_activity_preference_idempotent_not_exists(self, db_session_mock):
-        """Test updating an activity preference that doesn't exist"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = None
-        
-        update_data = RefActivityPreferenceUpdate(
-            PatientId=1,
-            ActivityId=1,
-            IsLike="0",
-            IsDeleted="0",
-            UpdatedDateTime=datetime.now(),
-            ModifiedById="test_user"
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_preference_duplicate_detected(mock_idempotent_process, db_session_mock, sample_created_ref_activity_preference_data, sample_activity_preference):
+    """Should return existing record if duplicate detected by idempotency service"""
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+
+    result, was_duplicate = create_ref_activity_preference(
+        db=db_session_mock,
+        preference=sample_created_ref_activity_preference_data,
+        correlation_id="corr_id_101",
+        created_by="test_user"
+    )
+
+    assert was_duplicate is True
+    assert result == sample_activity_preference
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_preference_foreign_key_patient_error(mock_idempotent_process, db_session_mock, sample_created_ref_activity_preference_data):
+    """Should raise foreign key error for invalid PatientID"""
+
+    # Mock no existing preference found
+    db_session_mock.query().filter().first.return_value = None
+    db_session_mock.add.side_effect = Exception("FOREIGN KEY constraint failed: REF_PATIENT")
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        create_ref_activity_preference(
+            db=db_session_mock,
+            preference=sample_created_ref_activity_preference_data,
+            correlation_id="corr_id_102",
+            created_by="test_user"
         )
-        
-        result = update_ref_activity_preference_idempotent(db_session_mock, 999, update_data, "test_user")
-        
-        assert result is None
-        db_session_mock.commit.assert_not_called()
+    assert "foreign key" in str(exc_info.value).lower()
+    db_session_mock.rollback.assert_called_once()
 
-    def test_soft_delete_ref_activity_preference_idempotent_exists(self, db_session_mock, sample_activity_preference):
-        """Test soft deleting an activity preference that exists"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = sample_activity_preference
-        
-        result = soft_delete_ref_activity_preference_idempotent(db_session_mock, 1, "test_user")
-        
-        assert sample_activity_preference.IsDeleted == "1"
-        db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once_with(sample_activity_preference)
-        assert result == sample_activity_preference
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_preference_foreign_key_activity_error(mock_idempotent_process, db_session_mock, sample_created_ref_activity_preference_data):
+    """Should raise foreign key error for invalid ActivityID"""
 
-    def test_get_ref_activity_preferences_with_filters(self, db_session_mock, sample_activity_preference):
-        """Test getting activity preferences with filters"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = [sample_activity_preference]
-        db_session_mock.query.return_value.scalar.return_value = 1
-        
-        preferences, total_records, total_pages = get_ref_activity_preferences(
-            db_session_mock,
-            pageNo=0,
-            pageSize=10,
-            patient_id=1,
-            activity_id=1,
-            is_like="1"
+    # Mock no existing preference found
+    db_session_mock.query().filter().first.return_value = None
+    db_session_mock.add.side_effect = Exception("FOREIGN KEY constraint failed: REF_ACTIVITY")
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        create_ref_activity_preference(
+            db=db_session_mock,
+            preference=sample_created_ref_activity_preference_data,
+            correlation_id="corr_id_102",
+            created_by="test_user"
         )
-        
-        assert len(preferences) == 1
-        assert preferences[0] == sample_activity_preference
-        assert total_records == 1
-        assert total_pages == 1
+    assert "foreign key" in str(exc_info.value).lower()
+    db_session_mock.rollback.assert_called_once()
 
-    def test_get_preferences_by_patient_and_activity_found(self, db_session_mock, sample_activity_preference):
-        """Test getting preference for a specific patient and activity"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.first.return_value = sample_activity_preference
-        
-        result = get_preferences_by_patient_and_activity(db_session_mock, 1, 1)
-        
-        assert result == sample_activity_preference
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_preference_update_existing_active(mock_idempotent_process, db_session_mock, sample_created_ref_activity_preference_data, sample_activity_preference):
+    """Should raise error when trying to create an preference that already exists as active"""
 
-    def test_get_patient_liked_activities(self, db_session_mock, sample_activity_preference):
-        """Test getting all activities liked by a patient"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [sample_activity_preference]
-        
-        result = get_patient_liked_activities(db_session_mock, 1)
-        
-        assert len(result) == 1
-        assert result[0] == sample_activity_preference
+    # Mock existing active preference found
+    sample_created_ref_activity_preference_data.CentreActivityPreferenceID = sample_activity_preference.CentreActivityPreferenceID
+    sample_activity_preference.IsDeleted = "0"
 
-    def test_get_patient_disliked_activities(self, db_session_mock):
-        """Test getting all activities disliked by a patient"""
-        disliked_preference = Mock()
-        disliked_preference.IsLike = "0"
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [disliked_preference]
-        
-        result = get_patient_disliked_activities(db_session_mock, 1)
-        
-        assert len(result) == 1
-        assert result[0] == disliked_preference
+    # Mock query to return existing active preference
+    db_session_mock.query().filter().first.side_effect = [sample_activity_preference]
+
+    def fake_process(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process
+
+    with pytest.raises(ValueError, match="already exists"):
+        create_ref_activity_preference(
+            db=db_session_mock,
+            preference=sample_created_ref_activity_preference_data,
+            correlation_id="corr_id_update_active",
+            created_by="test_user"
+        )
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.record_processed_event')
+def test_create_ref_activity_preference_skip_duplicate_check_record_fail(mock_record_processed_event, db_session_mock, sample_created_ref_activity_preference_data, sample_activity_preference):
+    """Skip duplicate check but record_processed_event fails (non-critical)"""
+
+    db_session_mock.query().filter().first.return_value = None
+    mock_record_processed_event.side_effect = Exception("DB not reachable")
+
+    with mock.patch('pear_schedule.crud.ref_activity_preference_crud.RefActivityPreference', return_value=sample_activity_preference):
+        result, was_duplicate = create_ref_activity_preference(
+            db=db_session_mock,
+            preference=sample_created_ref_activity_preference_data,
+            correlation_id="corr_skip_fail",
+            created_by="test_user",
+            skip_duplicate_check=True
+        )
+
+    assert result == sample_activity_preference
+    assert was_duplicate is False
+    db_session_mock.add.assert_called_once()
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_preference_duplicate_no_id(mock_idempotent_process, db_session_mock, sample_created_ref_activity_preference_data, sample_activity_preference):
+    """Covers else branch of was_duplicate handling when CentreActivityPreferenceID is None"""
+
+    # Remove CentreActivityPreferenceID to trigger else branch
+    sample_created_ref_activity_preference_data.CentreActivityPreferenceID = None
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True  # was_duplicate=True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    # Mock existing record returned by else-branch query
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+
+    result, was_duplicate = create_ref_activity_preference(
+        db=db_session_mock,
+        preference=sample_created_ref_activity_preference_data,
+        correlation_id="corr_no_id_dup",
+        created_by="test_user"
+    )
+
+    assert was_duplicate is True
+    assert result == sample_activity_preference
+
+# ==== update_ref_activity_preference tests ====
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_preference_success(mock_idempotent_process, db_session_mock, sample_updated_ref_activitiy_preference_data, sample_activity_preference):
+    """Should update an existing activity preference successfully"""
+
+    # Mock existing preference found
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation()
+        return result, False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    result, was_duplicate = update_ref_activity_preference(
+        db=db_session_mock,
+        preference_id=1,
+        preference_update=sample_updated_ref_activitiy_preference_data,
+        correlation_id="corr_update_123",
+    )
+    assert result == sample_activity_preference
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_preference_not_found(mock_idempotent_process, db_session_mock, sample_updated_ref_activitiy_preference_data):
+    """Should raise error when trying to update a non-existent activity preference"""
+
+    # Mock no existing preference found
+    db_session_mock.query().filter().first.return_value = None
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    result, was_duplicate = update_ref_activity_preference(
+        db=db_session_mock,
+        preference_id=999,
+        preference_update=sample_updated_ref_activitiy_preference_data,
+        correlation_id="corr_update_999",
+    )
+
+    assert result is None
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_preference_duplicate_event(mock_idempotent_process, db_session_mock, sample_updated_ref_activitiy_preference_data, sample_activity_preference):
+    """Should return existing record if duplicate detected by idempotency service during update"""
+
+    # Mock existing preference found
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = update_ref_activity_preference(
+        db=db_session_mock,
+        preference_id=1,
+        preference_update=sample_updated_ref_activitiy_preference_data,
+        correlation_id="corr_update_dup",
+    )
+
+    assert was_duplicate is True
+    assert result == sample_activity_preference
+    db_session_mock.commit.assert_not_called()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.record_processed_event')
+def test_update_ref_activity_preference_skip_duplicate_check(mock_record_processed_event, db_session_mock, sample_updated_ref_activitiy_preference_data, sample_activity_preference):
+    """Should update an existing activity preference without duplicate check"""
+
+    # Mock existing preference found
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+
+    mock_record_processed_event.return_value = None
+
+    result, was_duplicate = update_ref_activity_preference(
+        db=db_session_mock,
+        preference_id=1,
+        preference_update=sample_updated_ref_activitiy_preference_data,
+        correlation_id="corr_update_no_dup_check",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_activity_preference
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.record_processed_event')
+def test_update_ref_activity_preference_skip_duplicate_check_record_fail(mock_record_processed_event, db_session_mock, sample_updated_ref_activitiy_preference_data, sample_activity_preference):
+    """Skip duplicate check but record_processed_event fails (non-critical)"""
+
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+    mock_record_processed_event.side_effect = Exception("DB not reachable")
+
+    result, was_duplicate = update_ref_activity_preference(
+        db=db_session_mock,
+        preference_id=1,
+        preference_update=sample_updated_ref_activitiy_preference_data,
+        correlation_id="corr_update_skip_fail",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_activity_preference
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_preference_error(mock_idempotent_process, db_session_mock, sample_updated_ref_activitiy_preference_data, sample_activity_preference):
+    """Should handle error during update operation"""
+
+    # Mock existing preference found
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+    db_session_mock.commit.side_effect = Exception("DB not reachable")
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        update_ref_activity_preference(
+            db=db_session_mock,
+            preference_id=1,
+            preference_update=sample_updated_ref_activitiy_preference_data,
+            correlation_id="corr_update_error",
+        )
+    assert "DB not reachable" in str(exc_info.value)
+    db_session_mock.rollback.assert_called_once()
+
+# ==== delete_ref_activity_preference tests ====
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_preference_success(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_preference_data, sample_activity_preference):
+    """Should soft delete an existing activity preference successfully"""
+
+    # Mock existing preference found
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation()
+        return result, False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity_preference(
+        db=db_session_mock,
+        preference_id=1,
+        preference_delete=sample_deleted_ref_activity_preference_data,
+        correlation_id="corr_delete_123",
+    )
+
+    assert result == sample_activity_preference
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_preference_not_found(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_preference_data):
+    """Should raise error when trying to delete a non-existent activity preference"""
+
+    # Mock no existing preference found
+    db_session_mock.query().filter().first.return_value = None
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity_preference(
+        db=db_session_mock,
+        preference_id=999,
+        preference_delete=sample_deleted_ref_activity_preference_data,
+        correlation_id="corr_delete_999",
+    )
+
+    assert result is None
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_preference_already_deleted(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_preference_data, sample_activity_preference):
+    """Should handle already deleted activity preference gracefully"""
+
+    # Mock existing preference found and already deleted
+    sample_activity_preference.IsDeleted = "1"
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity_preference(
+        db=db_session_mock,
+        preference_id=1,
+        preference_delete=sample_deleted_ref_activity_preference_data,
+        correlation_id="corr_delete_already",
+    )
+
+    assert result == sample_activity_preference
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_preference_duplicate_event(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_preference_data, sample_activity_preference):
+    """Should return existing record if duplicate detected by idempotency service during delete"""
+
+    # Mock existing preference found
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity_preference(
+        db=db_session_mock,
+        preference_id=1,
+        preference_delete=sample_deleted_ref_activity_preference_data,
+        correlation_id="corr_delete_dup",
+    )
+
+    assert was_duplicate is True
+    assert result == sample_activity_preference
+    db_session_mock.commit.assert_not_called()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.record_processed_event')
+def test_delete_ref_activity_preference_skip_duplicate_check(mock_record_processed_event, db_session_mock, sample_deleted_ref_activity_preference_data, sample_activity_preference):
+    """Should soft delete an existing activity preference without duplicate check"""
+
+    # Mock existing preference found
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+
+    mock_record_processed_event.return_value = None
+
+    result, was_duplicate = delete_ref_activity_preference(
+        db=db_session_mock,
+        preference_id=1,
+        preference_delete=sample_deleted_ref_activity_preference_data,
+        correlation_id="corr_delete_no_dup_check",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_activity_preference
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.record_processed_event')
+def test_delete_ref_activity_preference_skip_duplicate_check_record_fail(mock_record_processed_event, db_session_mock, sample_deleted_ref_activity_preference_data, sample_activity_preference):
+    """Skip duplicate check but record_processed_event fails (non-critical)"""
+
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+    mock_record_processed_event.side_effect = Exception("DB not reachable")
+
+    result, was_duplicate = delete_ref_activity_preference(
+        db=db_session_mock,
+        preference_id=1,
+        preference_delete=sample_deleted_ref_activity_preference_data,
+        correlation_id="corr_delete_skip_fail",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_activity_preference
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_preference_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_preference_error(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_preference_data, sample_activity_preference):
+    """Should handle error during delete operation"""
+
+    # Mock existing preference found
+    db_session_mock.query().filter().first.return_value = sample_activity_preference
+    db_session_mock.commit.side_effect = Exception("DB not reachable")
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        delete_ref_activity_preference(
+            db=db_session_mock,
+            preference_id=1,
+            preference_delete=sample_deleted_ref_activity_preference_data,
+            correlation_id="corr_delete_error",
+        )
+    assert "DB not reachable" in str(exc_info.value)
+    db_session_mock.rollback.assert_called_once()
+    
+
+
+# ===== get_idempotency_stats tests ===
+def test_get_idempotency_stats(db_session_mock):
+    """Test fetching idempotency stats. Makes sure that get_idempotency_stats calls the service and returns its data."""
+    expected_stats = {
+        "total_processed_events": 10,
+        "events_last_24h": 2,
+        "events_with_errors": 1,
+        "events_by_type": [{"event_type": "ACTIVITY_CREATED", "count": 5}],
+        "latest_events": [],
+        "stats_generated_at": "2025-10-12T00:00:00"
+    }
+
+    with mock.patch.object(IdempotencyService, "get_processing_stats", return_value=expected_stats) as mock_get_stats:
+        results = get_idempotency_stats(db=db_session_mock)
+
+        assert results == expected_stats
+        mock_get_stats.assert_called_once_with(db_session_mock)
+
+# ===== cleanup_old_processed_events tests ===
+def test_cleanup_old_processed_events(db_session_mock):
+    """Test cleanup of old processed events. Ensures that cleanup_old_processed_events calls the service method."""
+
+    expected_deleted = 5
+    older_than_days = 60
+    with mock.patch.object(IdempotencyService, "cleanup_old_events", return_value=expected_deleted) as mock_cleanup:
+        result = cleanup_old_processed_events(db=db_session_mock, older_than_days=older_than_days)
+
+        assert result == expected_deleted
+
+        mock_cleanup.assert_called_once_with(db_session_mock, older_than_days)
+
+# ===== is_event_already_processed tests ===
+def test_is_event_already_processed(db_session_mock):
+    """Test checking if event is already processed. Ensures that is_event_already_processed calls the service method."""
+    with mock.patch.object(IdempotencyService, "is_already_processed", return_value=True) as mock_is_processed:
+        result = is_event_already_processed(
+            db=db_session_mock,
+            correlation_id="corr-123",
+        )
+
+        assert result is True
+        mock_is_processed.assert_called_once_with(db_session_mock, "corr-123")

--- a/tests/unit_tests/test_ref_activity_recommendation_crud.py
+++ b/tests/unit_tests/test_ref_activity_recommendation_crud.py
@@ -1,184 +1,623 @@
 import pytest
-from unittest.mock import Mock, patch
+from unittest import mock
 from datetime import datetime
+
 from pear_schedule.crud.ref_activity_recommendation_crud import (
-    create_or_update_ref_activity_recommendation,
-    update_ref_activity_recommendation_idempotent,
-    soft_delete_ref_activity_recommendation_idempotent,
-    get_ref_activity_recommendations,
-    get_ref_activity_recommendation_by_id,
-    get_recommendations_by_patient_and_activity,
-    get_doctor_recommendations_for_patient,
-    get_recommended_activities_for_patient
+    create_ref_activity_recommendation,
+    update_ref_activity_recommendation,
+    delete_ref_activity_recommendation,
+    get_idempotency_stats,
+    cleanup_old_processed_events,
+    is_event_already_processed
 )
-from pear_schedule.schemas.ref_activity_recommendation import RefActivityRecommendationCreate, RefActivityRecommendationUpdate
 
+from pear_schedule.schemas.ref_activity_recommendation import RefActivityRecommendationCreate, RefActivityRecommendationUpdate, RefActivityRecommendationDelete
+from pear_schedule.services.idempotency_service import IdempotencyService
 
-class TestRefActivityRecommendationCrud:
+@pytest.fixture
+def sample_created_ref_activity_recommendation_data():
+    return RefActivityRecommendationCreate(
+        PatientID= 1,
+        CentreActivityID=1,
+        IsLike="0",
+        IsDeleted="0",
+        CentreActivityRecommendationID=1,
+        CreatedDateTime=datetime(2025, 1, 1, 10, 0, 0),
+        UpdatedDateTime=datetime(2025, 1, 1, 10, 0, 0),
+        CreatedById="test_user",
+        ModifiedById="test_user"
+    )
+
+@pytest.fixture
+def sample_updated_ref_activitiy_recommendation_data():
+    return RefActivityRecommendationUpdate(
+        PatientId=1,
+        ActivityId=1,
+        IsDeleted=False,
+        IsLike="1",
+        UpdatedDateTime=datetime(2025, 1, 2, 10, 0, 0),
+        ModifiedById="test_user"
+    )
+
+@pytest.fixture
+def sample_deleted_ref_activity_recommendation_data():
+    return RefActivityRecommendationDelete(
+        UpdatedDateTime=datetime(2025, 1, 3, 10, 0, 0),
+        ModifiedById="test_user"
+    )
+
+# ===== create_ref_activity_recommendation tests ===
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_recommendation_success(mock_idempotent_process, db_session_mock, sample_created_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Should create a new activity recommendation successfully"""
+
+    # Mock no existing recommendation found
+    db_session_mock.query().filter().first.side_effect = [None, sample_activity_recommendation]
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation() # executes create_operation
+        return result, False
     
-    def test_create_or_update_ref_activity_recommendation_create_new(self, db_session_mock, sample_activity_recommendation):
-        """Test creating a new activity recommendation when one doesn't exist"""
-        # Mock that no existing recommendation is found
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.filter.return_value.first.return_value = None
-        
-        recommendation_data = RefActivityRecommendationCreate(
-            PatientId=1,
-            ActivityId=1,
-            DoctorId="doc123",
-            DoctorRecommendation="1",
-            DoctorRemarks="Good for mobility",
-            IsDeleted="0",
-            CreatedDateTime=datetime.now(),
-            UpdatedDateTime=datetime.now(),
-            CreatedById="test_user",
-            ModifiedById="test_user"
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.RefActivityRecommendation', return_value=sample_activity_recommendation):
+        result, was_duplicate = create_ref_activity_recommendation(
+            db=db_session_mock,
+            recommendation=sample_created_ref_activity_recommendation_data,
+            correlation_id="corr_id_123",
+            created_by="test_user"
         )
-        
-        # Mock refresh to set the Id after creation
-        def mock_refresh(obj):
-            obj.Id = 1
-        db_session_mock.refresh.side_effect = mock_refresh
-        
-        result = create_or_update_ref_activity_recommendation(db_session_mock, recommendation_data, "test_user")
-        
+
+        assert result == sample_activity_recommendation
+        assert was_duplicate is False
+        db_session_mock.add.assert_called_once()
+        db_session_mock.flush.assert_called_once()
+        db_session_mock.commit.assert_called_once()
+        mock_idempotent_process.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.record_processed_event')
+def test_create_ref_activity_recommendation_skip_duplicate_check(mock_records_processed_event, db_session_mock, sample_created_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Should create a new activity recommendation without duplicate check"""
+
+    # Mock no existing recommendation found
+    db_session_mock.query().filter().first.return_value = None
+    mock_records_processed_event.return_value = None
+
+    with mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.RefActivityRecommendation', return_value=sample_activity_recommendation):
+        result, was_duplicate = create_ref_activity_recommendation(
+            db=db_session_mock,
+            recommendation=sample_created_ref_activity_recommendation_data,
+            correlation_id="222", 
+            created_by="test_user",
+            skip_duplicate_check=True
+        )
+
+        assert result == sample_activity_recommendation
+        assert was_duplicate is False
         db_session_mock.add.assert_called_once()
         db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once()
+        mock_records_processed_event.assert_called_once()
+    
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_recommendation_reactivate_soft_deleted(mock_idempotent_process, db_session_mock, sample_created_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Should reactivate a soft-deleted activity recommendation"""
 
-    def test_create_or_update_ref_activity_recommendation_update_existing(self, db_session_mock, sample_activity_recommendation):
-        """Test updating an existing activity recommendation"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.filter.return_value.first.return_value = sample_activity_recommendation
-        
-        recommendation_data = RefActivityRecommendationCreate(
-            PatientId=1,
-            ActivityId=1,
-            DoctorId="doc123",
-            DoctorRecommendation="0",  # Changed from recommended to not recommended
-            DoctorRemarks="Updated remarks - not suitable anymore",
-            IsDeleted="0",
-            CreatedDateTime=datetime.now(),
-            UpdatedDateTime=datetime.now(),
-            CreatedById="test_user",
-            ModifiedById="test_user"
+    # Mock existing soft-deleted recommendation found
+    soft_deleted_recommendation = sample_activity_recommendation
+    soft_deleted_recommendation.IsDeleted = "1"
+    db_session_mock.query().filter().first.side_effect = [soft_deleted_recommendation, soft_deleted_recommendation]
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation()
+        return result, False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    with mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.RefActivityRecommendation', return_value=soft_deleted_recommendation):
+        result, was_duplicate = create_ref_activity_recommendation(
+            db=db_session_mock,
+            recommendation=sample_created_ref_activity_recommendation_data,
+            correlation_id="corr_id_456",
+            created_by="test_user"
         )
-        
-        result = create_or_update_ref_activity_recommendation(db_session_mock, recommendation_data, "test_user")
-        
+
+        assert result == soft_deleted_recommendation
+        assert result.IsDeleted == "0"
+        assert was_duplicate is False
         db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once_with(sample_activity_recommendation)
-        assert result == sample_activity_recommendation
 
-    def test_update_ref_activity_recommendation_idempotent_exists(self, db_session_mock, sample_activity_recommendation):
-        """Test updating an activity recommendation that exists"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = sample_activity_recommendation
-        
-        update_data = RefActivityRecommendationUpdate(
-            PatientId=1,
-            ActivityId=1,
-            DoctorId="doc123",
-            DoctorRecommendation="0",
-            DoctorRemarks="Updated recommendation",
-            IsDeleted="0",
-            UpdatedDateTime=datetime.now(),
-            ModifiedById="test_user"
+def test_create_ref_activity_recommendation_duplicate_raises(db_session_mock, sample_created_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Should raise error when trying to create a duplicate activity recommendation"""
+
+    # Mock existing recommendation found
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+
+    with pytest.raises(ValueError):
+        create_ref_activity_recommendation(
+            db=db_session_mock,
+            recommendation=sample_created_ref_activity_recommendation_data,
+            correlation_id="corr_id_789",
+            created_by="test_user"
         )
-        
-        result = update_ref_activity_recommendation_idempotent(db_session_mock, 1, update_data, "test_user")
-        
-        db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once_with(sample_activity_recommendation)
-        assert result == sample_activity_recommendation
 
-    def test_update_ref_activity_recommendation_idempotent_not_exists(self, db_session_mock):
-        """Test updating an activity recommendation that doesn't exist"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = None
-        
-        update_data = RefActivityRecommendationUpdate(
-            PatientId=1,
-            ActivityId=1,
-            DoctorId="doc123",
-            DoctorRecommendation="0",
-            DoctorRemarks="Updated recommendation",
-            IsDeleted="0",
-            UpdatedDateTime=datetime.now(),
-            ModifiedById="test_user"
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_recommendation_duplicate_detected(mock_idempotent_process, db_session_mock, sample_created_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Should return existing record if duplicate detected by idempotency service"""
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+
+    result, was_duplicate = create_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation=sample_created_ref_activity_recommendation_data,
+        correlation_id="corr_id_101",
+        created_by="test_user"
+    )
+
+    assert was_duplicate is True
+    assert result == sample_activity_recommendation
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_recommendation_foreign_key_patient_error(mock_idempotent_process, db_session_mock, sample_created_ref_activity_recommendation_data):
+    """Should raise foreign key error for invalid PatientID"""
+
+    # Mock no existing recommendation found
+    db_session_mock.query().filter().first.return_value = None
+    db_session_mock.add.side_effect = Exception("FOREIGN KEY constraint failed: REF_PATIENT")
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        create_ref_activity_recommendation(
+            db=db_session_mock,
+            recommendation=sample_created_ref_activity_recommendation_data,
+            correlation_id="corr_id_102",
+            created_by="test_user"
         )
-        
-        result = update_ref_activity_recommendation_idempotent(db_session_mock, 999, update_data, "test_user")
-        
-        assert result is None
-        db_session_mock.commit.assert_not_called()
+    assert "foreign key" in str(exc_info.value).lower()
+    db_session_mock.rollback.assert_called_once()
 
-    def test_soft_delete_ref_activity_recommendation_idempotent_exists(self, db_session_mock, sample_activity_recommendation):
-        """Test soft deleting an activity recommendation that exists"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = sample_activity_recommendation
-        
-        result = soft_delete_ref_activity_recommendation_idempotent(db_session_mock, 1, "test_user")
-        
-        assert sample_activity_recommendation.IsDeleted == "1"
-        db_session_mock.commit.assert_called_once()
-        db_session_mock.refresh.assert_called_once_with(sample_activity_recommendation)
-        assert result == sample_activity_recommendation
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_recommendation_foreign_key_activity_error(mock_idempotent_process, db_session_mock, sample_created_ref_activity_recommendation_data):
+    """Should raise foreign key error for invalid ActivityID"""
 
-    def test_get_ref_activity_recommendations_with_filters(self, db_session_mock, sample_activity_recommendation):
-        """Test getting activity recommendations with filters"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.filter.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = [sample_activity_recommendation]
-        db_session_mock.query.return_value.scalar.return_value = 1
-        
-        recommendations, total_records, total_pages = get_ref_activity_recommendations(
-            db_session_mock,
-            pageNo=0,
-            pageSize=10,
-            patient_id=1,
-            activity_id=1,
-            doctor_id="doc123",
-            is_recommended="1"
+    # Mock no existing recommendation found
+    db_session_mock.query().filter().first.return_value = None
+    db_session_mock.add.side_effect = Exception("FOREIGN KEY constraint failed: REF_ACTIVITY")
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        create_ref_activity_recommendation(
+            db=db_session_mock,
+            recommendation=sample_created_ref_activity_recommendation_data,
+            correlation_id="corr_id_102",
+            created_by="test_user"
         )
-        
-        assert len(recommendations) == 1
-        assert recommendations[0] == sample_activity_recommendation
-        assert total_records == 1
-        assert total_pages == 1
+    assert "foreign key" in str(exc_info.value).lower()
+    db_session_mock.rollback.assert_called_once()
 
-    def test_get_recommendations_by_patient_and_activity_found(self, db_session_mock, sample_activity_recommendation):
-        """Test getting recommendations for a specific patient and activity"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [sample_activity_recommendation]
-        
-        result = get_recommendations_by_patient_and_activity(db_session_mock, 1, 1)
-        
-        assert len(result) == 1
-        assert result[0] == sample_activity_recommendation
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_recommendation_update_existing_active(mock_idempotent_process, db_session_mock, sample_created_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Should raise error when trying to create an recommendation that already exists as active"""
 
-    def test_get_doctor_recommendations_for_patient(self, db_session_mock, sample_activity_recommendation):
-        """Test getting all recommendations by a doctor for a specific patient"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [sample_activity_recommendation]
-        
-        result = get_doctor_recommendations_for_patient(db_session_mock, 1, "doc123")
-        
-        assert len(result) == 1
-        assert result[0] == sample_activity_recommendation
+    # Mock existing active recommendation found
+    sample_created_ref_activity_recommendation_data.CentreActivityRecommendationID = sample_activity_recommendation.CentreActivityRecommendationID
+    sample_activity_recommendation.IsDeleted = "0"
 
-    def test_get_recommended_activities_for_patient(self, db_session_mock, sample_activity_recommendation):
-        """Test getting all recommended activities for a patient"""
-        db_session_mock.query.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = [sample_activity_recommendation]
-        
-        result = get_recommended_activities_for_patient(db_session_mock, 1)
-        
-        assert len(result) == 1
-        assert result[0] == sample_activity_recommendation
+    # Mock query to return existing active recommendation
+    db_session_mock.query().filter().first.side_effect = [sample_activity_recommendation]
 
-    def test_get_ref_activity_recommendation_by_id_found(self, db_session_mock, sample_activity_recommendation):
-        """Test getting an activity recommendation by ID when it exists"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = sample_activity_recommendation
-        
-        result = get_ref_activity_recommendation_by_id(db_session_mock, 1)
-        
-        assert result == sample_activity_recommendation
+    def fake_process(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
 
-    def test_get_ref_activity_recommendation_by_id_not_found(self, db_session_mock):
-        """Test getting an activity recommendation by ID when it doesn't exist"""
-        db_session_mock.query.return_value.filter.return_value.first.return_value = None
-        
-        result = get_ref_activity_recommendation_by_id(db_session_mock, 999)
-        
-        assert result is None
+    mock_idempotent_process.side_effect = fake_process
+
+    with pytest.raises(ValueError, match="already exists"):
+        create_ref_activity_recommendation(
+            db=db_session_mock,
+            recommendation=sample_created_ref_activity_recommendation_data,
+            correlation_id="corr_id_update_active",
+            created_by="test_user"
+        )
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.record_processed_event')
+def test_create_ref_activity_recommendation_skip_duplicate_check_record_fail(mock_record_processed_event, db_session_mock, sample_created_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Skip duplicate check but record_processed_event fails (non-critical)"""
+
+    db_session_mock.query().filter().first.return_value = None
+    mock_record_processed_event.side_effect = Exception("DB not reachable")
+
+    with mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.RefActivityRecommendation', return_value=sample_activity_recommendation):
+        result, was_duplicate = create_ref_activity_recommendation(
+            db=db_session_mock,
+            recommendation=sample_created_ref_activity_recommendation_data,
+            correlation_id="corr_skip_fail",
+            created_by="test_user",
+            skip_duplicate_check=True
+        )
+
+    assert result == sample_activity_recommendation
+    assert was_duplicate is False
+    db_session_mock.add.assert_called_once()
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_create_ref_activity_recommendation_duplicate_no_id(mock_idempotent_process, db_session_mock, sample_created_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Covers else branch of was_duplicate handling when CentreActivityRecommendationID is None"""
+
+    # Remove CentreActivityRecommendationID to trigger else branch
+    sample_created_ref_activity_recommendation_data.CentreActivityRecommendationID = None
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True  # was_duplicate=True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    # Mock existing record returned by else-branch query
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+
+    result, was_duplicate = create_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation=sample_created_ref_activity_recommendation_data,
+        correlation_id="corr_no_id_dup",
+        created_by="test_user"
+    )
+
+    assert was_duplicate is True
+    assert result == sample_activity_recommendation
+
+# ==== update_ref_activity_recommendation tests ====
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_recommendation_success(mock_idempotent_process, db_session_mock, sample_updated_ref_activitiy_recommendation_data, sample_activity_recommendation):
+    """Should update an existing activity recommendation successfully"""
+
+    # Mock existing recommendation found
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation()
+        return result, False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    result, was_duplicate = update_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation_id=1,
+        recommendation_update=sample_updated_ref_activitiy_recommendation_data,
+        correlation_id="corr_update_123",
+    )
+    assert result == sample_activity_recommendation
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_recommendation_not_found(mock_idempotent_process, db_session_mock, sample_updated_ref_activitiy_recommendation_data):
+    """Should raise error when trying to update a non-existent activity recommendation"""
+
+    # Mock no existing recommendation found
+    db_session_mock.query().filter().first.return_value = None
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+    result, was_duplicate = update_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation_id=999,
+        recommendation_update=sample_updated_ref_activitiy_recommendation_data,
+        correlation_id="corr_update_999",
+    )
+
+    assert result is None
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_recommendation_duplicate_event(mock_idempotent_process, db_session_mock, sample_updated_ref_activitiy_recommendation_data, sample_activity_recommendation):
+    """Should return existing record if duplicate detected by idempotency service during update"""
+
+    # Mock existing recommendation found
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = update_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation_id=1,
+        recommendation_update=sample_updated_ref_activitiy_recommendation_data,
+        correlation_id="corr_update_dup",
+    )
+
+    assert was_duplicate is True
+    assert result == sample_activity_recommendation
+    db_session_mock.commit.assert_not_called()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.record_processed_event')
+def test_update_ref_activity_recommendation_skip_duplicate_check(mock_record_processed_event, db_session_mock, sample_updated_ref_activitiy_recommendation_data, sample_activity_recommendation):
+    """Should update an existing activity recommendation without duplicate check"""
+
+    # Mock existing recommendation found
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+
+    mock_record_processed_event.return_value = None
+
+    result, was_duplicate = update_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation_id=1,
+        recommendation_update=sample_updated_ref_activitiy_recommendation_data,
+        correlation_id="corr_update_no_dup_check",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_activity_recommendation
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.record_processed_event')
+def test_update_ref_activity_recommendation_skip_duplicate_check_record_fail(mock_record_processed_event, db_session_mock, sample_updated_ref_activitiy_recommendation_data, sample_activity_recommendation):
+    """Skip duplicate check but record_processed_event fails (non-critical)"""
+
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+    mock_record_processed_event.side_effect = Exception("DB not reachable")
+
+    result, was_duplicate = update_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation_id=1,
+        recommendation_update=sample_updated_ref_activitiy_recommendation_data,
+        correlation_id="corr_update_skip_fail",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_activity_recommendation
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_update_ref_activity_recommendation_error(mock_idempotent_process, db_session_mock, sample_updated_ref_activitiy_recommendation_data, sample_activity_recommendation):
+    """Should handle error during update operation"""
+
+    # Mock existing recommendation found
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+    db_session_mock.commit.side_effect = Exception("DB not reachable")
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        update_ref_activity_recommendation(
+            db=db_session_mock,
+            recommendation_id=1,
+            recommendation_update=sample_updated_ref_activitiy_recommendation_data,
+            correlation_id="corr_update_error",
+        )
+    assert "DB not reachable" in str(exc_info.value)
+    db_session_mock.rollback.assert_called_once()
+
+# ==== delete_ref_activity_recommendation tests ====
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_recommendation_success(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Should soft delete an existing activity recommendation successfully"""
+
+    # Mock existing recommendation found
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+
+    # Mock idempotency service returns not duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        result = operation()
+        return result, False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation_id=1,
+        recommendation_delete=sample_deleted_ref_activity_recommendation_data,
+        correlation_id="corr_delete_123",
+    )
+
+    assert result == sample_activity_recommendation
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_recommendation_not_found(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_recommendation_data):
+    """Should raise error when trying to delete a non-existent activity recommendation"""
+
+    # Mock no existing recommendation found
+    db_session_mock.query().filter().first.return_value = None
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation_id=999,
+        recommendation_delete=sample_deleted_ref_activity_recommendation_data,
+        correlation_id="corr_delete_999",
+    )
+
+    assert result is None
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_recommendation_already_deleted(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Should handle already deleted activity recommendation gracefully"""
+
+    # Mock existing recommendation found and already deleted
+    sample_activity_recommendation.IsDeleted = "1"
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation_id=1,
+        recommendation_delete=sample_deleted_ref_activity_recommendation_data,
+        correlation_id="corr_delete_already",
+    )
+
+    assert result == sample_activity_recommendation
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_recommendation_duplicate_event(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Should return existing record if duplicate detected by idempotency service during delete"""
+
+    # Mock existing recommendation found
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+
+    # Mock idempotency service returns duplicate
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return None, True
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    result, was_duplicate = delete_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation_id=1,
+        recommendation_delete=sample_deleted_ref_activity_recommendation_data,
+        correlation_id="corr_delete_dup",
+    )
+
+    assert was_duplicate is True
+    assert result == sample_activity_recommendation
+    db_session_mock.commit.assert_not_called()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.record_processed_event')
+def test_delete_ref_activity_recommendation_skip_duplicate_check(mock_record_processed_event, db_session_mock, sample_deleted_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Should soft delete an existing activity recommendation without duplicate check"""
+
+    # Mock existing recommendation found
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+
+    mock_record_processed_event.return_value = None
+
+    result, was_duplicate = delete_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation_id=1,
+        recommendation_delete=sample_deleted_ref_activity_recommendation_data,
+        correlation_id="corr_delete_no_dup_check",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_activity_recommendation
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.record_processed_event')
+def test_delete_ref_activity_recommendation_skip_duplicate_check_record_fail(mock_record_processed_event, db_session_mock, sample_deleted_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Skip duplicate check but record_processed_event fails (non-critical)"""
+
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+    mock_record_processed_event.side_effect = Exception("DB not reachable")
+
+    result, was_duplicate = delete_ref_activity_recommendation(
+        db=db_session_mock,
+        recommendation_id=1,
+        recommendation_delete=sample_deleted_ref_activity_recommendation_data,
+        correlation_id="corr_delete_skip_fail",
+        skip_duplicate_check=True
+    )
+
+    assert result == sample_activity_recommendation
+    assert result.IsDeleted == "1"
+    assert was_duplicate is False
+    db_session_mock.commit.assert_called_once()
+    mock_record_processed_event.assert_called_once()
+
+@mock.patch('pear_schedule.crud.ref_activity_recommendation_crud.IdempotencyService.process_idempotent')
+def test_delete_ref_activity_recommendation_error(mock_idempotent_process, db_session_mock, sample_deleted_ref_activity_recommendation_data, sample_activity_recommendation):
+    """Should handle error during delete operation"""
+
+    # Mock existing recommendation found
+    db_session_mock.query().filter().first.return_value = sample_activity_recommendation
+    db_session_mock.commit.side_effect = Exception("DB not reachable")
+
+    def fake_process_idempotent(db, correlation_id, event_type, aggregate_id, processed_by, operation):
+        return operation(), False
+
+    mock_idempotent_process.side_effect = fake_process_idempotent
+
+    with pytest.raises(Exception) as exc_info:
+        delete_ref_activity_recommendation(
+            db=db_session_mock,
+            recommendation_id=1,
+            recommendation_delete=sample_deleted_ref_activity_recommendation_data,
+            correlation_id="corr_delete_error",
+        )
+    assert "DB not reachable" in str(exc_info.value)
+    db_session_mock.rollback.assert_called_once()
+    
+
+
+# ===== get_idempotency_stats tests ===
+def test_get_idempotency_stats(db_session_mock):
+    """Test fetching idempotency stats. Makes sure that get_idempotency_stats calls the service and returns its data."""
+    expected_stats = {
+        "total_processed_events": 10,
+        "events_last_24h": 2,
+        "events_with_errors": 1,
+        "events_by_type": [{"event_type": "ACTIVITY_CREATED", "count": 5}],
+        "latest_events": [],
+        "stats_generated_at": "2025-10-12T00:00:00"
+    }
+
+    with mock.patch.object(IdempotencyService, "get_processing_stats", return_value=expected_stats) as mock_get_stats:
+        results = get_idempotency_stats(db=db_session_mock)
+
+        assert results == expected_stats
+        mock_get_stats.assert_called_once_with(db_session_mock)
+
+# ===== cleanup_old_processed_events tests ===
+def test_cleanup_old_processed_events(db_session_mock):
+    """Test cleanup of old processed events. Ensures that cleanup_old_processed_events calls the service method."""
+
+    expected_deleted = 5
+    older_than_days = 60
+    with mock.patch.object(IdempotencyService, "cleanup_old_events", return_value=expected_deleted) as mock_cleanup:
+        result = cleanup_old_processed_events(db=db_session_mock, older_than_days=older_than_days)
+
+        assert result == expected_deleted
+
+        mock_cleanup.assert_called_once_with(db_session_mock, older_than_days)
+
+# ===== is_event_already_processed tests ===
+def test_is_event_already_processed(db_session_mock):
+    """Test checking if event is already processed. Ensures that is_event_already_processed calls the service method."""
+    with mock.patch.object(IdempotencyService, "is_already_processed", return_value=True) as mock_is_processed:
+        result = is_event_already_processed(
+            db=db_session_mock,
+            correlation_id="corr-123",
+        )
+
+        assert result is True
+        mock_is_processed.assert_called_once_with(db_session_mock, "corr-123")


### PR DESCRIPTION
added unit tests for
- ref_activity_crud
- ref_activity_exclusion_crud
- ref_activity_preference_crud
- ref_activity_recommendation_crud
- ref_centre_activity_crud

did not do unit test for activity routine because i saw that it isn't updated
also updated conftest.py to make the sample data updated with the updated schema