### PR TITLE
set k8 tz to asia/singapore

### DIFF
--- a/k8s/scheduler_deployment_dev.yaml
+++ b/k8s/scheduler_deployment_dev.yaml
@@ -18,6 +18,9 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
+        env:
+        - name: TZ
+          value: "Asia/Singapore"  # GMT+8 timezone
         envFrom:
         - configMapRef:
             name: scheduler-service-dev-env


### PR DESCRIPTION
- fix integrity endpoint version timestamp showing into the future