### PR TITLE
Chore/migrate db marcus

### DIFF
--- a/configprod.py
+++ b/configprod.py
@@ -49,3 +49,5 @@ GROUP_TIMESLOT_MAPPING = [(0,1), (0,6), (0,7), (1,1), (1,6), (1,7), (2,1), (2,6)
 TARGET_WEEKLY_GROUP_ACTIVITIES = 6
 DAY_OF_WEEK_ORDER = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 DAY_TIMESLOTS = ["9am-10am", "10am-11am", "11am-12pm", "12pm-1pm", "1pm-2pm","2pm-3pm","3pm-4pm", "4pm-5pm"]
+MIN_ACTIVITY_DURATION: int = 60 # in minutes
+OPENING_HOUR = "9am"

--- a/messaging/mappers/mapper_util.py
+++ b/messaging/mappers/mapper_util.py
@@ -287,7 +287,7 @@ class MapperUtil:
                     # Direct mappings (source_field: target_field)
                     'id': 'ActivityExclusionID',
                     'patient_id': 'PatientID',
-                    'centre_activity_id': 'ActivityID',
+                    'centre_activity_id': 'CentreActivityID',
                     'start_date': 'StartDateTime',
                     'end_date': 'EndDateTime', 
                     'exclusion_remarks': 'ExclusionRemarks',

--- a/pear_schedule/api/integrity_router.py
+++ b/pear_schedule/api/integrity_router.py
@@ -277,7 +277,7 @@ async def get_ref_centre_activity_exclusion_integrity(
         for exclusion in ref_exclusions:
             records.append({
                 "ActivityExclusionID": exclusion.ActivityExclusionID,
-                "ActivityID": exclusion.ActivityID,
+                "CentreActivityID": exclusion.CentreActivityID,
                 "PatientID": exclusion.PatientID,
                 "modified_date": exclusion.UpdatedDateTime.isoformat(),
                 "version_timestamp": int(exclusion.UpdatedDateTime.timestamp() * 1000),

--- a/pear_schedule/crud/ref_activity_exclusion_crud.py
+++ b/pear_schedule/crud/ref_activity_exclusion_crud.py
@@ -47,7 +47,7 @@ def create_ref_activity_exclusion(
                     logger.info(f"Reactivating soft-deleted exclusion {exclusion.ActivityExclusionID}")
                     existing.IsDeleted = "0"
                     existing.PatientID = exclusion.PatientID
-                    existing.ActivityID = exclusion.ActivityID
+                    existing.CentreActivityID = exclusion.CentreActivityID
                     existing.StartDateTime = exclusion.StartDateTime
                     existing.EndDateTime = exclusion.EndDateTime
                     existing.ExclusionRemarks = exclusion.ExclusionRemarks
@@ -60,12 +60,12 @@ def create_ref_activity_exclusion(
         else:
             existing = db.query(RefActivityExclusion).filter(
                 RefActivityExclusion.PatientID == exclusion.PatientID,
-                RefActivityExclusion.ActivityID == exclusion.ActivityID,
+                RefActivityExclusion.CentreActivityID == exclusion.CentreActivityID,
                 RefActivityExclusion.IsDeleted == "0"
             ).first()
             
             if existing:
-                logger.info(f"Found existing exclusion for Patient {exclusion.PatientID}, Activity {exclusion.ActivityID}")
+                logger.info(f"Found existing exclusion for Patient {exclusion.PatientID}, Activity {exclusion.CentreActivityID}")
                 existing.StartDateTime = exclusion.StartDateTime
                 existing.EndDateTime = exclusion.EndDateTime
                 existing.ExclusionRemarks = exclusion.ExclusionRemarks
@@ -74,11 +74,11 @@ def create_ref_activity_exclusion(
                 db.flush()
                 return existing
         
-        logger.info(f"Creating new activity exclusion for Patient {exclusion.PatientID}, Activity {exclusion.ActivityID}")
+        logger.info(f"Creating new activity exclusion for Patient {exclusion.PatientID}, Activity {exclusion.CentreActivityID}")
         
         new_exclusion = RefActivityExclusion(
             PatientID=exclusion.PatientID,
-            ActivityID=exclusion.ActivityID,
+            CentreActivityID=exclusion.CentreActivityID,
             StartDateTime=exclusion.StartDateTime,
             EndDateTime=exclusion.EndDateTime,
             ExclusionRemarks=exclusion.ExclusionRemarks,
@@ -96,7 +96,7 @@ def create_ref_activity_exclusion(
         db.flush()
         return new_exclusion
     
-    aggregate_key = str(exclusion.ActivityExclusionID) if hasattr(exclusion, 'ActivityExclusionID') and exclusion.ActivityExclusionID else f"{exclusion.PatientID}_{exclusion.ActivityID}"
+    aggregate_key = str(exclusion.ActivityExclusionID) if hasattr(exclusion, 'ActivityExclusionID') and exclusion.ActivityExclusionID else f"{exclusion.PatientID}_{exclusion.CentreActivityID}"
     
     try:
         if skip_duplicate_check:
@@ -132,7 +132,7 @@ def create_ref_activity_exclusion(
             else:
                 existing_exclusion = db.query(RefActivityExclusion).filter(
                     RefActivityExclusion.PatientID == exclusion.PatientID,
-                    RefActivityExclusion.ActivityID == exclusion.ActivityID,
+                    RefActivityExclusion.CentreActivityID == exclusion.CentreActivityID,
                     RefActivityExclusion.IsDeleted == "0"
                 ).first()
             logger.info(f"Duplicate create event for activity exclusion {aggregate_key}, returning existing")

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -319,17 +319,19 @@ class CompulsoryActivitiesOnlyView(BaseView): # Just compulsory activities only
         activity = schema.tables[cls.db_tables.ACTIVITY_TABLE]
 
         query: Select = select(
-            centre_activity.c["ActivityID"],
+            # centre_activity.c["ActivityID"],
             activity.c["ActivityTitle"],
             centre_activity.c["IsFixed"],
             centre_activity.c["FixedTimeSlots"],
+            centre_activity.c["MinDuration"],
         ).join(
             activity, activity.c["ActivityID"] == centre_activity.c["ActivityID"]
-        ).where(centre_activity.c["IsCompulsory"] == True
-        ).where(centre_activity.c["IsDeleted"] == False
         ).where(
-        centre_activity.c["EndDate"] > get_next_sunday(),
-        centre_activity.c["StartDate"] < get_monday(),
+            centre_activity.c["IsCompulsory"] == True,
+            centre_activity.c["IsDeleted"] == False,
+            centre_activity.c["IsFixed"] == True,
+            centre_activity.c["EndDate"] > get_next_sunday(),
+            centre_activity.c["StartDate"] < get_monday(),
         ) #EndDate has been moved from ActivityTable to CentreActivity Table
 
         return query
@@ -361,6 +363,7 @@ class RecommendedActivitiesView(BaseView):
             recommendations.c["DoctorRecommendation"] > 0,
             centre_activity.c["IsGroup"] == False,
             centre_activity.c["StartDate"] < get_monday(),
+            centre_activity.c["EndDate"] > get_next_sunday(),
             centre_activity.c["IsCompulsory"] == False
         )
 
@@ -388,8 +391,9 @@ class DisrecommendedActivitiesView(BaseView):
             recommendations, recommendations.c["CentreActivityID"] == centre_activity.c["CentreActivityID"]
         ).where(
             recommendations.c["IsDeleted"] == False,
-            recommendations.c["DoctorRecommendation"] == 0,
+            recommendations.c["DoctorRecommendation"] == -1,
             centre_activity.c["IsGroup"] == False,
+            centre_activity.c["IsDeleted"] == False,
         )
 
         return query
@@ -406,7 +410,7 @@ class MedicationView(BaseView): # Just medication table view
         query: Select = select(
             medication,
         ).where(
-            medication.c["EndDateTime"] >= curDateTime 
+            # medication.c["EndDateTime"] >= curDateTime 
         )
         return query
 #ROUTINETable Not Ready, add in once ready.
@@ -631,7 +635,7 @@ class ActivitiesExcludedView(BaseView): # Get the activities excluded for all pa
         
         query: Select = select(
             activities_excluded.c["ActivityExclusionID"], 
-            activities_excluded.c["CentreActivityID"],
+            centre_activity.c["ActivityID"],
             activities_excluded.c["PatientID"],
             activities_excluded.c["ExclusionRemarks"],
             activities_excluded.c["EndDateTime"],
@@ -646,8 +650,8 @@ class ActivitiesExcludedView(BaseView): # Get the activities excluded for all pa
                 activities_excluded.c["EndDateTime"] == None
             )
         ).where(
-            activities_excluded.c['IsDeleted'] == False,
-            activity.c['IsDeleted'] == False
+            activities_excluded.c["IsDeleted"] == False,
+            centre_activity.c["IsDeleted"] == False
         )
         
         return query

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -121,6 +121,7 @@ class PatientsView(BaseView):
         ).where(
             centre_activity_preference.c["IsLike"] > 0,
             centre_activity_preference.c["IsDeleted"] == False,
+            centre_activity.c["IsDeleted"] == False,
             centre_activity.c["StartDate"] < get_monday(),
         ).cte()
 

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -299,7 +299,7 @@ class GroupActivitiesExclusionView(BaseView): # Just group activities preference
             centre_activity.c["CentreActivityID"],
             activity_exclusion.c["PatientID"],
         ).join(
-            activity_exclusion, centre_activity.c["ActivityID"] == activity_exclusion.c["ActivityID"] 
+            activity_exclusion, centre_activity.c["CentreActivityID"] == activity_exclusion.c["CentreActivityID"] 
         ).where(centre_activity.c["IsGroup"] == True
         ).where(activity_exclusion.c["IsDeleted"] == False
         ).where(or_(and_( activity_exclusion.c["EndDateTime"] >= start_of_week, activity_exclusion.c["StartDateTime"] <= end_of_week) ,activity_exclusion.c["EndDateTime"] == None)
@@ -626,24 +626,28 @@ class ActivitiesExcludedView(BaseView): # Get the activities excluded for all pa
         start_of_week = curDateTime - timedelta(days=curDateTime.weekday(), hours=0, minutes=0, seconds=0)  # Monday -> 00:00:00
         
         activity = schema.tables[cls.db_tables.ACTIVITY_TABLE]
+        centre_activity = schema.tables[cls.db_tables.CENTRE_ACTIVITY_TABLE]
         activities_excluded = schema.tables[cls.db_tables.ACTIVITY_EXCLUSION_TABLE]
         
         query: Select = select(
             activities_excluded.c["ActivityExclusionID"], 
-            activities_excluded.c["ActivityID"],
+            activities_excluded.c["CentreActivityID"],
             activities_excluded.c["PatientID"],
             activities_excluded.c["ExclusionRemarks"],
             activities_excluded.c["EndDateTime"],
             activity.c["ActivityTitle"]
         ).join(
-            activity, activity.c["ActivityID"] == activities_excluded.c["ActivityID"]
+            centre_activity, centre_activity.c["CentreActivityID"] == activities_excluded.c["CentreActivityID"]
+        ).join(
+            activity, activity.c["ActivityID"] == centre_activity.c["ActivityID"]
         ).where(
             or_(
                 activities_excluded.c["EndDateTime"] >= start_of_week, 
                 activities_excluded.c["EndDateTime"] == None
             )
         ).where(
-            activities_excluded.c['IsDeleted'] == False
+            activities_excluded.c['IsDeleted'] == False,
+            activity.c['IsDeleted'] == False
         )
         
         return query

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -206,6 +206,7 @@ class GroupActivitiesOnlyView(BaseView): # Just group activities only
 
         query: Select = select(
             centre_activity.c["ActivityID"],
+            centre_activity.c["CentreActivityID"],
             activity.c["ActivityTitle"],
             centre_activity.c["IsFixed"],
             centre_activity.c["FixedTimeSlots"],
@@ -241,8 +242,12 @@ class GroupActivitiesPreferenceView(BaseView): # Just group activities preferenc
         ).join(
             centre_activity_preference, centre_activity.c["CentreActivityID"] == centre_activity_preference.c["CentreActivityID"] 
         ).where(centre_activity.c["IsGroup"] == True
-        ).where(centre_activity_preference.c["IsDeleted"] == False
-        ).where(centre_activity.c["StartDate"] < get_monday(),
+        ).where(
+            centre_activity_preference.c["IsDeleted"] == False,
+            centre_activity.c["IsDeleted"] == False,
+        ).where(
+            centre_activity.c["StartDate"] < get_monday(),
+            centre_activity.c["EndDate"] > get_next_sunday(),
         )
 
 
@@ -267,8 +272,12 @@ class GroupActivitiesRecommendationView(BaseView): # Just group activities prefe
         ).join(
             centre_activity_recommendation, centre_activity.c["CentreActivityID"] == centre_activity_recommendation.c["CentreActivityID"] 
         ).where(centre_activity.c["IsGroup"] == True
-        ).where(centre_activity_recommendation.c["IsDeleted"] == False
-        ).where(centre_activity.c["StartDate"] < get_monday(),
+        ).where(
+            centre_activity_recommendation.c["IsDeleted"] == False,
+            centre_activity.c["IsDeleted"] == False,
+        ).where(
+            centre_activity.c["StartDate"] < get_monday(),
+            centre_activity.c["EndDate"] > get_next_sunday(),
         )
 
 
@@ -301,7 +310,9 @@ class GroupActivitiesExclusionView(BaseView): # Just group activities preference
         ).join(
             activity_exclusion, centre_activity.c["CentreActivityID"] == activity_exclusion.c["CentreActivityID"] 
         ).where(centre_activity.c["IsGroup"] == True
-        ).where(activity_exclusion.c["IsDeleted"] == False
+        ).where(
+            activity_exclusion.c["IsDeleted"] == False,
+            centre_activity.c["IsDeleted"] == False,
         ).where(or_(and_( activity_exclusion.c["EndDateTime"] >= start_of_week, activity_exclusion.c["StartDateTime"] <= end_of_week) ,activity_exclusion.c["EndDateTime"] == None)
         )
 

--- a/pear_schedule/models/ref_activity_exclusion_model.py
+++ b/pear_schedule/models/ref_activity_exclusion_model.py
@@ -9,7 +9,7 @@ class RefActivityExclusion(Base):
     ActivityExclusionID = Column(Integer, primary_key=True, index=True) 
     IsDeleted = Column(String(1), default='0', nullable=False)
     PatientID = Column(Integer, ForeignKey('REF_PATIENT.PatientID')) 
-    ActivityID = Column(Integer, ForeignKey('REF_ACTIVITY.ActivityID')) 
+    CentreActivityID = Column(Integer, ForeignKey('REF_CENTRE_ACTIVITY.CentreActivityID')) 
     StartDateTime = Column(DateTime, nullable=False)
     EndDateTime = Column(DateTime, nullable=False)
     ExclusionRemarks = Column(String(255))
@@ -20,4 +20,4 @@ class RefActivityExclusion(Base):
     ModifiedById = Column(String, nullable=False)
 
     patient = relationship("RefPatient", back_populates="exclusions")
-    activity = relationship("RefActivity", back_populates="exclusions")
+    centre_activity = relationship("RefCentreActivity", back_populates="exclusions")

--- a/pear_schedule/models/ref_activity_model.py
+++ b/pear_schedule/models/ref_activity_model.py
@@ -16,6 +16,5 @@ class RefActivity(Base):
     CreatedById = Column(String, nullable=False)
     ModifiedById = Column(String, nullable=False) 
 
-    exclusions = relationship("RefActivityExclusion", back_populates="activity")
     routines = relationship("RefActivityRoutine", back_populates="activity")
     centre_activities = relationship("RefCentreActivity", back_populates="activity")

--- a/pear_schedule/models/ref_centre_activity_model.py
+++ b/pear_schedule/models/ref_centre_activity_model.py
@@ -28,3 +28,4 @@ class RefCentreActivity(Base):
     activity = relationship("RefActivity", back_populates="centre_activities")
     preferences = relationship("RefActivityPreference", back_populates="centre_activity")
     recommendations = relationship("RefActivityRecommendation", back_populates="centre_activity")
+    exclusions = relationship("RefActivityExclusion", back_populates="centre_activity")

--- a/pear_schedule/scheduler/compulsoryScheduling.py
+++ b/pear_schedule/scheduler/compulsoryScheduling.py
@@ -7,14 +7,19 @@ class CompulsoryActivityScheduler(BaseScheduler):
     def fillSchedule(cls, patientSchedules: Mapping[str, List[str]]):
         compulsoryActivitiesDF = CompulsoryActivitiesOnlyView.get_data()
         # Compulsory Activity 
-        for _, row in compulsoryActivitiesDF.query("IsFixed=='1'").loc[:, ["ActivityTitle", "FixedTimeSlots"]].astype(str).iterrows():
+        for _, row in compulsoryActivitiesDF.iterrows():
         
             fixedSlotArr = row["FixedTimeSlots"].split(",")
             for slot in fixedSlotArr:
                 
+                # TODO: placeholder - For activities whose duration is more than 1 slot, assume that the slot in FixedTimeSlots denotes the starting slot
                 day = int(slot.split("-")[0])
                 hour = int(slot.split("-")[1])
+                duration_slots = -(row["MinDuration"] // -cls.config["MIN_ACTIVITY_DURATION"]) - 1
 
                 for pid in patientSchedules.keys():
                     patientSchedules[pid][day][hour] = row["ActivityTitle"]
+                    for d in range(1, duration_slots + 1):
+                        patientSchedules[pid][day][hour + d] = row["ActivityTitle"] # ? trust activity handling will not go past closing hour
+
 

--- a/pear_schedule/scheduler/groupScheduling.py
+++ b/pear_schedule/scheduler/groupScheduling.py
@@ -38,29 +38,37 @@ class GroupActivityScheduler(BaseScheduler):
         for _, record in groupActivityDF.iterrows():
             patients = totalPatientSet.copy()
             
-            activityID = record["ActivityID"]
+            centreActivityID = record["CentreActivityID"]
             activityTitle = record["ActivityTitle"]
             minSizeRequired = record["MinPeopleReq"]
 
             activityMinSizeMap[activityTitle] = minSizeRequired
 
             # Find excluded patients from activity
-            excludedDF = groupExcludedDF.query(f"CentreActivityID == {activityID}")
+            excludedDF = groupExcludedDF[groupExcludedDF["CentreActivityID"] == centreActivityID]
             for id in excludedDF["PatientID"]:
                 activityExclusionMap[activityTitle].add(id)
                 if id in patients:
                     patients.remove(id)
 
             # Find not recommended patients
-            notRecommendedDF = groupRecommendationDF.query(f"CentreActivityID == {activityID} and DoctorRecommendation == False")
+            notRecommendedDF = groupRecommendationDF[
+                (groupRecommendationDF["CentreActivityID"] == centreActivityID) &
+                (groupRecommendationDF["DoctorRecommendation"].astype(int) == -1)
+            ]
             for id in notRecommendedDF["PatientID"]:
                 activityExclusionMap[activityTitle].add(id)
                 if id in patients:
                     patients.remove(id)
+            with open("medication_schedule_debug.txt", "a") as f:
+                f.write(notRecommendedDF.to_string()+"\n")
 
 
             # Find recommended patients of activity
-            recommendedDF = groupRecommendationDF.query(f"CentreActivityID == {activityID} and DoctorRecommendation == True")
+            recommendedDF = groupRecommendationDF[
+                (groupRecommendationDF["CentreActivityID"] == centreActivityID) &
+                (groupRecommendationDF["DoctorRecommendation"].astype(int) == 1)
+            ]
             for id in recommendedDF["PatientID"]:
                 if id in patients:
                     activityMap[activityTitle].add(id)
@@ -69,7 +77,7 @@ class GroupActivityScheduler(BaseScheduler):
             
         
             # Find preferred patients of activity
-            preferredDF = groupPreferenceDF.query(f"CentreActivityID == {activityID} and IsLike == 1")
+            preferredDF = groupPreferenceDF.query(f"CentreActivityID == {centreActivityID} and IsLike == 1")
             for id in preferredDF["PatientID"]:
                 if id in patients and id not in activityExclusionMap[activityTitle]:
                     activityMap[activityTitle].add(id)

--- a/pear_schedule/scheduler/individualScheduling.py
+++ b/pear_schedule/scheduler/individualScheduling.py
@@ -42,7 +42,7 @@ class IndividualActivityScheduler(BaseScheduler):
             p["ActivityEndDate"] = Timestamp(p["ActivityEndDate"])
             if pid not in patients:
                 patients[pid] = {
-                    "preferences":dict(), "exclusions": dict(), "dispreferences": dict()  # recommendations handled in compulsory scheduling
+                    "preferences":set(), "exclusions": dict(), "dispreferences": set()  # recommendations handled in compulsory scheduling
                 }
             
             # If ActivityEndDate is null, means the Activity will restart every week. #ToBeConfirmed
@@ -51,24 +51,26 @@ class IndividualActivityScheduler(BaseScheduler):
                 continue
 
 
-            patients[pid]["preferences"][p["PreferredActivityID"]] = True
+            patients[pid]["preferences"].add(p["PreferredActivityID"])
 
         # add unpreferred/neutral activities
         for _, p in PatientsUnpreferredView.get_data(conn=conn).iterrows():
             pid = p["PatientID"]
             if pid not in patients:
                 patients[pid] = {
-                    "preferences":dict(), "exclusions": dict(), "dispreferences": dict()  # recommendations handled in compulsory scheduling
+                    "preferences":set(), "exclusions": dict(), "dispreferences": set()  # recommendations handled in compulsory scheduling
                 }
+            if Timestamp(p["ActivityEndDate"]) <= week_end:
+                continue
 
-            patients[pid]["dispreferences"][p["DispreferredActivityID"]] = True
+            patients[pid]["dispreferences"].add(p["DispreferredActivityID"])
 
         # add activity exclusions to patient data
         for _ , e in ActivitiesExcludedView.get_data(conn=conn).iterrows():
             pid = e["PatientID"]
             if pid not in patients:
                 patients[pid] = {
-                    "preferences":dict(), "exclusions": dict(), "dispreferences": dict()  # recommendations handled in compulsory scheduling
+                    "preferences":set(), "exclusions": dict(), "dispreferences": set()  # recommendations handled in compulsory scheduling
                 }
             activity_id = e["ActivityID"]
             if e["ActivityID"] not in patients[pid]["exclusions"]:
@@ -83,7 +85,7 @@ class IndividualActivityScheduler(BaseScheduler):
             pid = r["PatientID"]
             if pid not in patients:
                 patients[pid] = {
-                    "preferences":dict(), "exclusions": dict(), "dispreferences": dict()  # recommendations handled in compulsory scheduling
+                    "preferences":set(), "exclusions": dict(), "dispreferences": set()  # recommendations handled in compulsory scheduling
                 }
             activity_id = r["ActivityID"]
             patients[pid]["exclusions"][activity_id] = week_end
@@ -104,6 +106,11 @@ class RecommendedRoutineActivityScheduler(IndividualActivityScheduler):
             recommendations: pd.DataFrame = RecommendedActivitiesView.get_data(conn=conn)
             recommendations.sort_values(by=["PatientID"])
             recommendations["FixedTimeSlots"] = recommendations["FixedTimeSlots"].astype(str)
+
+            # break down fixedTimeSlots into a list (day,slot) pairs
+            proc_fixedTimeSlots:pd.Series = recommendations["FixedTimeSlots"].apply(lambda x: {(int(a),int(b)) for a,b in map(lambda y: y.split('-'), x.split(','))})
+            recommendations = recommendations.assign(ProcessedTimeSlots=proc_fixedTimeSlots)
+
             #convert to pd.timestamp to handle as activityenddate is beyond 2999, and it needs to be datetime
             recommendations["ActivityEndDate"] = recommendations["ActivityEndDate"].apply(pd.Timestamp)
  
@@ -176,7 +183,7 @@ class RecommendedRoutineActivityScheduler(IndividualActivityScheduler):
                         continue
 
                     # curr_availability: activity can be scheduled at this slot or at later slots (it has higher availability if the number of said slots is high)
-                    curr_availability: int = calculate_activity_availabillity(day, slot, activity["FixedTimeSlots"])
+                    curr_availability: int = calculate_activity_availabillity(day, slot, activity["ProcessedTimeSlots"])
 
                     # if there are no such slots, we are done with this activity, i.e. cannot be scheduled anymore, or was scheduled
                     if not curr_availability:
@@ -290,6 +297,11 @@ class PreferredActivityScheduler(IndividualActivityScheduler):
 
         # consolidate activity data
         activities: pd.DataFrame = ActivitiesView.get_data(conn=conn)  # non compulsory individual activities
+        avail_activities = activities[["ActivityID", "ActivityTitle", "FixedTimeSlots", "MinDuration", "MaxDuration"]]
+
+        # to be used in _findActivityBySlot, do preprocessing here instead of for every patient slot
+        proc_fixedTimeSlots:pd.Series = avail_activities['FixedTimeSlots'].apply(lambda x: [(int(a),int(b)) for a,b in map(lambda y: y.split('-'), x.split(','))])
+        avail_activities = avail_activities.assign(ProcessedTimeSlots=proc_fixedTimeSlots)
         # activities = activities.sample(frac=1)\
         #     .reset_index(drop=True)
 
@@ -299,17 +311,16 @@ class PreferredActivityScheduler(IndividualActivityScheduler):
                 continue
             patient = patients[pid]
 
-            exclusions: Set[str] = patient["exclusions"]
-            preferences: Set[str] = patient["preferences"]
-            dispreferences: Set[str] = patient["dispreferences"]
+            exclusions: Set[int] = patient["exclusions"]
+            preferences: Set[int] = patient["preferences"]
+            dispreferences: Set[int] = patient["dispreferences"]
 
-            avail_activities = activities[~activities["ActivityID"].isin(exclusions)]
-            avail_activities = avail_activities[["ActivityID", "ActivityTitle", "FixedTimeSlots", "MinDuration", "MaxDuration"]]
+            patient_activities = avail_activities[~avail_activities["ActivityID"].isin(exclusions)]
 
-            preference_idx = avail_activities["ActivityID"].isin(preferences)
-            non_preference_idx = (~avail_activities["ActivityID"].isin(dispreferences)) & ~preference_idx
-            preferred_activities = avail_activities[preference_idx]
-            non_preferred_activites = avail_activities[non_preference_idx]
+            preference_idx = patient_activities["ActivityID"].isin(preferences)
+            non_preference_idx = (~patient_activities["ActivityID"].isin(dispreferences)) & ~preference_idx
+            preferred_activities = patient_activities[preference_idx]
+            non_preferred_activites = patient_activities[non_preference_idx]
 
             for day, day_sched in enumerate(sched):
                 curr_day_activities = set()
@@ -367,8 +378,7 @@ class PreferredActivityScheduler(IndividualActivityScheduler):
 
             if a["FixedTimeSlots"]:
                 # e.g. takes in ["1-2","1-3"], map output: [["1","2"],["1","3"]]
-                timeSlots = [[int(x),int(y)] for x,y in map(lambda x: x.split("-"), a["FixedTimeSlots"].split(","))]
-                timeSlots = [t for t in timeSlots if t[0] == day and t[1] == slot and t[1] + minSlots <= slot + slot_size]
+                timeSlots = [t for t in a["ProcessedTimeSlots"] if t[0]==day and t[1]==slot and t[1]+minSlots<=slot+slot_size]
 
                 if not timeSlots:
                     continue
@@ -503,21 +513,15 @@ class PreferredActivityScheduler(IndividualActivityScheduler):
 
 
 
-def calculate_activity_availabillity(day: int, slot: int, fixedTimeSlots: str):
+def calculate_activity_availabillity(day: int, slot: int, processedTimeSlots: Set[tuple]) -> int:
     # first check whether activity can be scheduled at all at this slot
-    if f"{day}-{slot}" not in fixedTimeSlots:
+    if (day,slot) not in processedTimeSlots:
         return float("inf")
 
     # give priority to activities that have fixed time slots
-    if not fixedTimeSlots:
+    if not processedTimeSlots:
         return 1000
-
-    time_slots = fixedTimeSlots.split(",")
-
-    def validate(ts: str):
-        d, s = ts.split("-")
-        return int(d) > day or (int(d) == day and int(s) >= slot)
     
-    tally = sum(map(validate, time_slots))
+    tally = sum([1 for d,s in processedTimeSlots if d>day or (d==day and s>=slot)])
     
     return tally

--- a/pear_schedule/scheduler/individualScheduling.py
+++ b/pear_schedule/scheduler/individualScheduling.py
@@ -73,7 +73,7 @@ class IndividualActivityScheduler(BaseScheduler):
                     "preferences":set(), "exclusions": dict(), "dispreferences": set()  # recommendations handled in compulsory scheduling
                 }
             activity_id = e["ActivityID"]
-            if e["ActivityID"] not in patients[pid]["exclusions"]:
+            if activity_id not in patients[pid]["exclusions"]:
                 patients[pid]["exclusions"][activity_id] = e["EndDateTime"]
             else:
                 patients[pid]["exclusions"][activity_id] = _get_max_enddate(
@@ -104,7 +104,7 @@ class RecommendedRoutineActivityScheduler(IndividualActivityScheduler):
         with DB.get_engine().begin() as conn:
             # pull recommendations
             recommendations: pd.DataFrame = RecommendedActivitiesView.get_data(conn=conn)
-            recommendations.sort_values(by=["PatientID"])
+            recommendations = recommendations.sort_values(by=["PatientID"])
             recommendations["FixedTimeSlots"] = recommendations["FixedTimeSlots"].astype(str)
 
             # break down fixedTimeSlots into a list (day,slot) pairs
@@ -114,8 +114,8 @@ class RecommendedRoutineActivityScheduler(IndividualActivityScheduler):
             #convert to pd.timestamp to handle as activityenddate is beyond 2999, and it needs to be datetime
             recommendations["ActivityEndDate"] = recommendations["ActivityEndDate"].apply(pd.Timestamp)
  
-            # filter out activities that are not available this week
-            recommendations = recommendations[(recommendations["ActivityEndDate"] > week_end)] #| (recommendations["ActivityEndDate"].isna())]
+            # filter out activities that are not available this week, i.e. only consider activities that run past week_end
+            # recommendations = recommendations[(recommendations["ActivityEndDate"] > week_end)] #| (recommendations["ActivityEndDate"].isna())]
 
             # add an extra row at end for easier handling of final patient
             dummy_row = recommendations.iloc[0:1].copy(deep=True)
@@ -162,6 +162,7 @@ class RecommendedRoutineActivityScheduler(IndividualActivityScheduler):
             datetime.datetime.now() - datetime.timedelta(days = datetime.datetime.now().weekday())
 
         scheduled_idx = pd.Series(False, index=activities.index) # refers to all activities recommended to a specific patient
+        
         for day, day_schedule in enumerate(patient_schedule):
 
             if scheduled_idx.all():
@@ -176,7 +177,8 @@ class RecommendedRoutineActivityScheduler(IndividualActivityScheduler):
                 least_available = -1
                 lowest_availability = float("inf")
 
-                for row, activity in activities[~scheduled_idx].iterrows():
+                available_activities: pd.DataFrame = activities[~scheduled_idx]
+                for row, activity in available_activities.iterrows():
                     if checkActivityExcluded(
                         activity["ActivityID"], patient_info["exclusions"], day, week_start
                     ):
@@ -192,8 +194,10 @@ class RecommendedRoutineActivityScheduler(IndividualActivityScheduler):
                     if curr_availability < lowest_availability:
                         least_available = row
                         lowest_availability = curr_availability
-
-                if least_available < 0:
+                    
+                if least_available < 0 and not available_activities.empty:
+                    continue
+                elif least_available < 0 and available_activities.empty:
                     break
 
                 # attempt to schedule the most constrained activity first, because other activities have higher availability and should thus be able to be scheduled later
@@ -285,8 +289,6 @@ class RecommendedRoutineActivityScheduler(IndividualActivityScheduler):
 
 
 class PreferredActivityScheduler(IndividualActivityScheduler):
-    MIN_ACTIVITY_DURATION: int = 60 # in minutes
-
     @classmethod
     def fillSchedule(cls, schedules: Mapping[str, List[str]]) -> None:
         cls.fillPreferences(schedules)
@@ -373,7 +375,7 @@ class PreferredActivityScheduler(IndividualActivityScheduler):
                 continue
 
             # may change, but technically min duration is 30 mins; for now, 60 minutes.
-            minDuration = max(1, a["MinDuration"] // cls.MIN_ACTIVITY_DURATION) 
+            minDuration = max(1, a["MinDuration"] // cls.config["MIN_ACTIVITY_DURATION"]) 
             minSlots = minDuration - 1 # slots are 1 hour each
 
             if a["FixedTimeSlots"]:

--- a/pear_schedule/scheduler/medicationScheduling.py
+++ b/pear_schedule/scheduler/medicationScheduling.py
@@ -1,7 +1,10 @@
+import logging
 import datetime
 from typing import List, Mapping
 from pear_schedule.scheduler.baseScheduler import BaseScheduler
 from pear_schedule.db_utils.views import MedicationView
+
+logger = logging.getLogger(__name__)
 
 class medicationScheduler(BaseScheduler):
     @classmethod
@@ -29,7 +32,7 @@ class medicationScheduler(BaseScheduler):
             if startDateTime <= start_of_week: # Medication starts either before or start of this week
                 pass
             elif startDateTime > start_of_week and startDateTime <= end_of_week: # Medication starts sometime this week
-                start_day_counter = (start_of_week - startDateTime).days * -1
+                start_day_counter = (startDateTime - start_of_week).days
             else: # Medication does not start this week
                 continue
             # print(f"Medication starts on {start_day_counter}")
@@ -43,40 +46,58 @@ class medicationScheduler(BaseScheduler):
             slots = administerTime.split(",")
             
             for slot in slots:
-                hour = getTimeSlot(int(slot))
+                hour = getTimeSlot(cls, int(slot))
+                full_hour = cls.config["DAY_TIMESLOTS"][hour]
                 if hour == -1: # Invalid time-slot
                     continue
                 
                 for day in range(start_day_counter, end_day_counter+1):
+                    full_day = cls.config["DAY_OF_WEEK_ORDER"][day]
+                    s = "{begin}@{slot}: {prescription}({dosage}){end}"
+                    s = s.format(
+                        begin = " | Give Medication" if "Give Medication" not in patientSchedules[pid][day][hour] else ", Give Medication",
+                        slot = slot,
+                        prescription = row['PrescriptionName'],
+                        dosage = row['Dosage'],
+                        end = "" if instruction is None or not instruction.strip() or instruction.lower() in ["nil", "-"] else f"**{instruction}"
+                    )
                     
-                    if "Give Medication" not in patientSchedules[pid][day][hour]:
-                        if instruction is None or instruction.strip() == "" or instruction in ["Nil", "nil" "-"]: 
-                            patientSchedules[pid][day][hour] += f" | Give Medication@{slot}: {row['PrescriptionName']}({row['Dosage']})"
-                        else:
-                            patientSchedules[pid][day][hour] += f" | Give Medication@{slot}: {row['PrescriptionName']}({row['Dosage']})**{instruction}"
-                    else:
-                        if instruction is None or instruction.strip() == "" or instruction in ["Nil", "nil" "-"]:
-                            patientSchedules[pid][day][hour] += f", Give Medication@{slot}: {row['PrescriptionName']}({row['Dosage']})"
-                        else:
-                            patientSchedules[pid][day][hour] += f", Give Medication@{slot}: {row['PrescriptionName']}({row['Dosage']})**{instruction}"
+                    patientSchedules[pid][day][hour] += s
 
-def getTimeSlot(time):
-    if (900 <= time < 1000):
-        return 0
-    elif (1000 <= time < 1100):
-        return 1
-    elif (1100 <= time < 1200):
-        return 2
-    elif (1200 <= time < 1300):
-        return 3
-    elif (1300 <= time < 1400):
-        return 4
-    elif (1400 <= time < 1500):
-        return 5
-    elif (1500 <= time < 1600):
-        return 6
-    elif (1600 <= time < 1700):
-        return 7
-    else:
-        print("Invalid time-slot")
-        return -1
+
+def getTimeSlot(cls, time):
+    """
+    getTimeSlot() returns the index of the time slot based on the given time.
+    
+    Args:
+        cls: class in order to access config variables
+        time: administration time of medicine
+    
+    Returns:
+        Index of time slot, -1 if invalid time-slot, >len(cls.config["DAY_TIMESLOTS"]) if beyond closing hours, both would be out of bounds on access
+        E.g. 1730 administration time returns 8, 0830 returns -1
+    """
+    parsed_time = datetime.datetime.strptime(str(time), "%H%M")
+    timeDiff_fromOpening: datetime.timedelta = parsed_time-datetime.datetime.strptime(cls.config["OPENING_HOUR"], "%I%p")
+    numSlotsFromOpening: int = (timeDiff_fromOpening // -datetime.timedelta(minutes=cls.config["MIN_ACTIVITY_DURATION"])) * -1
+    return numSlotsFromOpening - 1
+
+    # if (900 <= time < 1000):
+    #     return 0
+    # elif (1000 <= time < 1100):
+    #     return 1
+    # elif (1100 <= time < 1200):
+    #     return 2
+    # elif (1200 <= time < 1300):
+    #     return 3
+    # elif (1300 <= time < 1400):
+    #     return 4
+    # elif (1400 <= time < 1500):
+    #     return 5
+    # elif (1500 <= time < 1600):
+    #     return 6
+    # elif (1600 <= time < 1700):
+    #     return 7
+    # else:
+    #     print("Invalid time-slot")
+    #     return -1

--- a/pear_schedule/schemas/ref_activity_exclusion.py
+++ b/pear_schedule/schemas/ref_activity_exclusion.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 class RefActivityExclusionBase(BaseModel):
     PatientID: int
-    ActivityID: int
+    CentreActivityID: int
     StartDateTime: datetime 
     EndDateTime: datetime
     ExclusionRemarks: Optional[str] = None
@@ -21,7 +21,7 @@ class RefActivityExclusionCreate(RefActivityExclusionBase):
 
 class RefActivityExclusionUpdate(BaseModel):
     PatientID: Optional[int] = None
-    ActivityID: Optional[int] = None
+    CentreActivityID: Optional[int] = None
     IsDeleted: Optional[bool] # DriftSync will update isdeleted if there are discrepency with delete records
     StartDateTime: Optional[datetime] = None
     EndDateTime: Optional[datetime] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def sample_activity_exclusion():
     return RefActivityExclusion(
         ActivityExclusionID=1,
         PatientID=1,
-        ActivityID=1,
+        CentreActivityID=1,
         StartDateTime=datetime(2024, 1, 1),
         EndDateTime=datetime(2024, 1, 7),
         ExclusionRemarks="Patient has mobility issues",

--- a/tests/integration_tests/test_activity_exclusion_consumer_integration.py
+++ b/tests/integration_tests/test_activity_exclusion_consumer_integration.py
@@ -328,12 +328,12 @@ class TestConsumerActivityExclusionCreate:
         
         assert ref_exclusion is not None
         assert ref_exclusion.PatientID == mock_exclusion_data["patient_id"]
-        assert ref_exclusion.ActivityID == mock_exclusion_data["centre_activity_id"]
+        assert ref_exclusion.CentreActivityID == mock_exclusion_data["centre_activity_id"]
         assert ref_exclusion.IsDeleted == "0"
         
         print(f"DONE: Created REF_ACTIVITY_EXCLUSION ID: {ref_exclusion.ActivityExclusionID}")
         print(f"  PatientID: {ref_exclusion.PatientID}")
-        print(f"  ActivityID: {ref_exclusion.ActivityID}")
+        print(f"  CentreActivityID: {ref_exclusion.CentreActivityID}")
         print(f"  IsDeleted: {ref_exclusion.IsDeleted}")
         
         # Verify PROCESSED_EVENTS record created

--- a/tests/unit_tests/test_ref_activity_exclusion_crud.py
+++ b/tests/unit_tests/test_ref_activity_exclusion_crud.py
@@ -18,7 +18,7 @@ def sample_created_ref_activity_exclusion_data():
     return RefActivityExclusionCreate(
         ActivityExclusionID=1,
         PatientID=10,
-        ActivityID=5,
+        CentreActivityID=5,
         StartDateTime=datetime.now(),
         EndDateTime=datetime.now(),
         ExclusionRemarks="Initial Remarks",
@@ -32,7 +32,7 @@ def sample_created_ref_activity_exclusion_data():
 def sample_updated_ref_activitiy_exclusion_data():
     return RefActivityExclusionUpdate(
         PatientID=20,
-        ActivityID=10,
+        CentreActivityID=10,
         IsDeleted="0",
         StartDateTime=datetime.now(),
         EndDateTime=datetime.now(),


### PR DESCRIPTION
1. Rename ActivityID to CentreActivityID of REF_ACTIVITY_EXCLUSION table, which references CentreActivityID of REF_CENTRE_ACTIVITY table instead of REF_ACTIVITY for consistency (following REF_ACTIVITY_RECOMMENDATION, REF_ACTIVITY_PREFERENCE)
2. Adjust views. DisrecommendedActivitiesView should query for DoctorRecommendation == -1 instead of 0. These activities are excluded from being scheduled for the patient as per business logic.
3. Adjusted scheduler to be able to schedule 30 or 60 minute compulsory activities.
4. Refactor: Remove repeated unnecessary processing steps of fixedTimeSlots, i.e. parsing "1-2" into [[1,2]]. 
5. Fix an instance whereby no activity being schedulable at a specific slot will cause the algorithm to exit early, despite the fact that it may be schedulable at a later slot.
6. Fix to avail_availabilities (a variable in an outer scope) from being overwritten, replace with patient_activities in loop, to prevent case where avail_availabilities narrow on each patient iteration
7. Fixed a bug in medication scheduling involving the normalization of negative hour to always be positive, i.e. +0 days -8 hours will be normalized to -1 day + 16 hours, resulting in incorrect timedelta arithmetic wrt to day.
8. Refactor: Replace hardcoding of getTimeSlot in medication scheduling which first parses str(time), then calculates the slot wrt to centre opening hour.