### PR TITLE
implement patient allocation MQ + integration test

### DIFF
--- a/messaging/consumer_manager.py
+++ b/messaging/consumer_manager.py
@@ -1,16 +1,17 @@
 import logging
 import threading
 import time
-from typing import List, Dict
 from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, List
 
-from .patient_consumer import PatientConsumer
-from .patient_medication_consumer import PatientMedicationConsumer
 from .activity_consumer import ActivityConsumer
 from .activity_exclusion_consumer import ActivityExclusionConsumer
 from .activity_preference_consumer import ActivityPreferenceConsumer
 from .activity_recommendation_consumer import ActivityRecommendationConsumer
 from .centre_activity_consumer import CentreActivityConsumer
+from .patient_allocation_consumer import PatientAllocationConsumer
+from .patient_consumer import PatientConsumer
+from .patient_medication_consumer import PatientMedicationConsumer
 
 logger = logging.getLogger(__name__)
 
@@ -189,6 +190,7 @@ def create_scheduler_consumer_manager() -> ConsumerManager:
     # Register all available consumers
     manager.register_consumer("patient", PatientConsumer)
     manager.register_consumer("patient_medication", PatientMedicationConsumer)
+    manager.register_consumer("patient_allocation", PatientAllocationConsumer)
     manager.register_consumer("activity", ActivityConsumer)
     manager.register_consumer("activity_exclusion", ActivityExclusionConsumer)
     manager.register_consumer("activity_preference", ActivityPreferenceConsumer)

--- a/messaging/mappers/mapper_util.py
+++ b/messaging/mappers/mapper_util.py
@@ -1,6 +1,6 @@
-from typing import Dict, Any, Optional, List, Callable
-from datetime import datetime, date
 import logging
+from datetime import date, datetime
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +104,48 @@ class MapperUtil:
                     'patient', 'prescription_list'  # SQLAlchemy relationship fields
                 ]
             },
-            
+            # Patient Allocation mapping (Patient Service -> Scheduler Service)
+            'patient_allocation_service_to_scheduler': {
+                'source_service': 'patient-service',
+                'target_service': 'scheduler-service',
+                'entity_type': 'patient_allocation',
+                'required_fields': ['id', 'patientId', 'doctorId', 'gameTherapistId', 
+                                   'supervisorId', 'caregiverId'],
+                'field_mappings': {
+                    'id': 'id',
+                    'active': 'active',
+                    'isDeleted': 'is_deleted',
+                    'patientId': 'patient_id',
+                    'doctorId': 'doctor_id',
+                    'gameTherapistId': 'game_therapist_id',
+                    'supervisorId': 'supervisor_id',
+                    'caregiverId': 'caregiver_id',
+                    'tempDoctorId': 'temp_doctor_id',
+                    'tempCaregiverId': 'temp_caregiver_id',
+                    'createdDate': 'created_date',
+                    'modifiedDate': 'modified_date',
+                    'CreatedById': 'created_by_id',
+                    'ModifiedById': 'modified_by_id',
+                },
+                'field_transforms': {
+                    'is_deleted': lambda x: self._convert_boolean(x, "0"),
+                    'created_date': lambda x: self._parse_datetime(x) or datetime.now(),
+                    'modified_date': lambda x: self._parse_datetime(x) or datetime.now(),
+                    'temp_doctor_id': lambda x: str(x) if x is not None else None,
+                    'temp_caregiver_id': lambda x: str(x) if x is not None else None,
+                },
+                'defaults': {
+                    'active': 'Y',
+                    'is_deleted': '0',
+                    'created_by_id': 'patient_service',
+                    'modified_by_id': 'patient_service'
+                },
+                'ignored_fields': [
+                    # Ignore guardian relationships for now
+                    'guardianId', 'guardian2Id'
+                ]
+            },
+                    
             # Activity Service → Scheduler Service
             'activity_service_to_scheduler': {
                 'source_service': 'activity-service',
@@ -667,6 +708,20 @@ def update_patient_medication_field_mapping(source_field: str, target_field: str
 def add_patient_medication_ignored_field(field_name: str):
     """Add field to patient medication ignore list"""
     mapper.add_ignored_field('patient_medication_service_to_scheduler', field_name)
+    
+def map_patient_allocation_create(source_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Map patient allocation data for create operation"""
+    return mapper.map_data(source_data, 'patient_allocation_service_to_scheduler', 'create')
+
+
+def map_patient_allocation_update(source_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Map patient allocation data for update operation"""
+    return mapper.map_data(source_data, 'patient_allocation_service_to_scheduler', 'update')
+
+
+def get_patient_allocation_mapping_info() -> Optional[Dict[str, Any]]:
+    """Get patient allocation mapping information"""
+    return mapper.get_mapping_info('patient_allocation_service_to_scheduler')
 
 # Convenience functions for activity preference mapper
 def map_activity_preference_create(source_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/messaging/patient_allocation_consumer.py
+++ b/messaging/patient_allocation_consumer.py
@@ -1,0 +1,470 @@
+import logging
+import threading
+import json
+from typing import Dict, Any, Optional
+from datetime import datetime
+from contextlib import contextmanager
+
+from .rabbitmq_client import RabbitMQClient
+from pear_schedule.models.processed_events_model import MessageProcessingResult
+
+logger = logging.getLogger(__name__)
+
+
+class PatientAllocationConsumer:
+    """
+    Consumer for patient allocation events with separated CRUD operations.
+    
+    This consumer processes patient allocation events from the patient.updates exchange
+    and updates the scheduler's local REF_PATIENT_ALLOCATION table with idempotency guarantees.
+    """
+    
+    def __init__(self):
+        self.client = RabbitMQClient("scheduler-patient-allocation-consumer")
+        self.allocation_queues = [
+            "scheduler.patient.allocation.created",
+            "scheduler.patient.allocation.updated",
+            "scheduler.patient.allocation.deleted"
+        ]
+        self.shutdown_event = None
+        self.is_consuming = False
+        
+        from pear_schedule.crud.ref_patient_allocation_crud import (
+            create_ref_patient_allocation,
+            update_ref_patient_allocation,
+            delete_ref_patient_allocation,
+            is_event_already_processed
+        )
+        from pear_schedule.database import get_db
+        from messaging.mappers.mapper_util import (
+            map_patient_allocation_create,
+            map_patient_allocation_update
+        )
+        
+        self.create_ref_patient_allocation = create_ref_patient_allocation
+        self.update_ref_patient_allocation = update_ref_patient_allocation
+        self.delete_ref_patient_allocation = delete_ref_patient_allocation
+        self.is_event_already_processed = is_event_already_processed
+        self.get_db = get_db
+        
+        self.map_patient_allocation_create = map_patient_allocation_create
+        self.map_patient_allocation_update = map_patient_allocation_update
+    
+    @contextmanager
+    def get_db_transaction(self):
+        """Context manager for database transactions with proper cleanup"""
+        db = next(self.get_db())
+        try:
+            logger.debug("Started database session transaction")
+            yield db
+            logger.debug("Database session transaction completed")
+        except Exception as e:
+            logger.error(f"Rolling back transaction due to error: {e}")
+            db.rollback()
+            raise
+        finally:
+            db.close()
+            logger.debug("Closed database session")
+    
+    def _flush_logs(self):
+        """Force flush all log handlers to ensure logs are written immediately"""
+        try:
+            for handler in logging.getLogger().handlers:
+                handler.flush()
+            for handler in logger.handlers:
+                handler.flush()
+        except Exception:
+            pass
+    
+    def set_shutdown_event(self, shutdown_event: threading.Event):
+        """Set the shutdown event for graceful shutdown"""
+        self.shutdown_event = shutdown_event
+        if self.client:
+            self.client.set_shutdown_event(shutdown_event)
+    
+    def setup_consumer(self):
+        """Set up consumer to listen to existing patient allocation queues"""
+        try:
+            self.client.connect()
+            
+            self.client.channel.exchange_declare(
+                exchange='patient.updates',
+                exchange_type='topic',
+                durable=True
+            )
+            
+            for queue_name in self.allocation_queues:
+                self.client.consume(queue_name, self._handle_message_wrapper)
+                logger.info(f"Set up consumer for scheduler queue: {queue_name}")
+            
+            logger.info("Scheduler patient allocation consumer setup complete")
+            
+        except Exception as e:
+            logger.error(f"Failed to setup scheduler patient allocation consumer: {str(e)}")
+            raise
+    
+    def start_consuming(self):
+        """Start consuming messages"""
+        try:
+            self.setup_consumer()
+            logger.info("Starting scheduler patient allocation consumer...")
+            self.is_consuming = True
+            self.client.start_consuming()
+        except Exception as e:
+            logger.error(f"Error starting scheduler patient allocation consumer: {str(e)}")
+            raise
+        finally:
+            self.is_consuming = False
+    
+    def stop(self):
+        """Stop the consumer gracefully"""
+        logger.info("Stopping patient allocation consumer...")
+        self.is_consuming = False
+        if self.client:
+            self.client.stop_consuming()
+    
+    def _handle_message_wrapper(self, message: Dict[str, Any]) -> bool:
+        """Wrapper for message handling with proper acknowledgment logic."""
+        try:
+            message_correlation = message.get('data', {}).get('correlation_id', 'UNKNOWN')
+            logger.debug(f"RECEIVED MESSAGE: correlation_id={message_correlation}")
+            
+            if self.shutdown_event and self.shutdown_event.is_set():
+                logger.info("Shutdown signal received, stopping message processing")
+                return False
+            
+            result = self._process_patient_allocation_message(message)
+            self._flush_logs()
+            
+            if result == MessageProcessingResult.SUCCESS:
+                logger.debug("Message processed successfully")
+                return True
+            elif result == MessageProcessingResult.DUPLICATE:
+                logger.info("Duplicate message processed (idempotent)")
+                return True
+            elif result == MessageProcessingResult.FAILED_RETRYABLE:
+                logger.warning("Message processing failed (retryable)")
+                return False
+            elif result == MessageProcessingResult.FAILED_PERMANENT:
+                logger.error("Message processing failed permanently")
+                return True
+            else:
+                logger.error(f"Unknown processing result: {result}")
+                return False
+                
+        except Exception as e:
+            logger.error(f"Fatal error in message wrapper: {str(e)}")
+            import traceback
+            logger.error(f"Full traceback: {traceback.format_exc()}")
+            self._flush_logs()
+            return False
+    
+    def _process_patient_allocation_message(
+        self, 
+        message: Dict[str, Any]
+    ) -> MessageProcessingResult:
+        """Process patient allocation message with sync event support."""
+        try:
+            message_data = self._parse_message(message)
+            if not message_data:
+                return MessageProcessingResult.FAILED_PERMANENT
+            
+            correlation_id = message_data['correlation_id']
+            event_type = message_data['event_type']
+            allocation_id = message_data['allocation_id']
+            is_sync_event = message_data.get('is_sync_event', False)
+            sync_reason = message_data.get('sync_reason')
+            
+            logger.info(
+                f"Processing {event_type} for allocation {allocation_id} "
+                f"(correlation: {correlation_id}, sync: {is_sync_event}, reason: {sync_reason})"
+            )
+            
+            with self.get_db_transaction() as db:
+                # For sync events, bypass duplicate check in CRUD
+                if not is_sync_event and self.is_event_already_processed(db, correlation_id):
+                    logger.info(f"Event already processed: {correlation_id}")
+                    return MessageProcessingResult.DUPLICATE
+                elif is_sync_event:
+                    logger.info(
+                        f"Sync event detected - bypassing idempotency check "
+                        f"for {correlation_id}"
+                    )
+                
+                if event_type == 'PATIENT_ALLOCATION_CREATED':
+                    result = self._handle_patient_allocation_created(db, message_data)
+                elif event_type == 'PATIENT_ALLOCATION_UPDATED':
+                    result = self._handle_patient_allocation_updated(db, message_data)
+                elif event_type == 'PATIENT_ALLOCATION_DELETED':
+                    result = self._handle_patient_allocation_deleted(db, message_data)
+                else:
+                    logger.error(f"Unknown event type: {event_type}")
+                    return MessageProcessingResult.FAILED_PERMANENT
+                
+                logger.debug(f"Transaction completed for {correlation_id}")
+            
+            verification_db = next(self.get_db())
+            try:
+                verified = self.is_event_already_processed(verification_db, correlation_id)
+                if not verified:
+                    logger.error(
+                        f"CRITICAL: processed_events record missing for {correlation_id}"
+                    )
+                    return MessageProcessingResult.FAILED_RETRYABLE
+            finally:
+                verification_db.close()
+                
+            return result
+            
+        except Exception as e:
+            logger.error(f"Error processing patient allocation message: {str(e)}")
+            import traceback
+            logger.error(f"Full traceback: {traceback.format_exc()}")
+            return MessageProcessingResult.FAILED_RETRYABLE
+    
+    def _parse_message(self, message: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Parse and validate message structure."""
+        try:
+            message_data = message.get('data', {})
+            
+            required_fields = ['correlation_id', 'event_type', 'allocation_id']
+            for field in required_fields:
+                if field not in message_data:
+                    logger.error(f"Missing required field '{field}' in message")
+                    return None
+            
+            logger.debug(f"Parsed message: {message_data}")
+            return message_data
+            
+        except Exception as e:
+            logger.error(f"Failed to parse message: {str(e)}")
+            return None
+    
+    def _handle_patient_allocation_created(
+        self, 
+        db, 
+        message_data: Dict[str, Any]
+    ) -> MessageProcessingResult:
+        """Handle patient allocation creation events"""
+        try:
+            correlation_id = message_data['correlation_id']
+            allocation_id = message_data['allocation_id']
+            allocation_data = message_data.get('allocation_data', {})
+            created_by = message_data.get('created_by', 'patient_service')
+            
+            logger.info(f"Handling patient allocation creation for allocation {allocation_id}")
+            logger.debug(f"Allocation data: {allocation_data}")
+            
+            mapped_allocation_data = self.map_patient_allocation_create(allocation_data)
+            if not mapped_allocation_data:
+                logger.error(f"Failed to map allocation data for allocation {allocation_id}")
+                logger.debug(f"Source data: {allocation_data}")
+                return MessageProcessingResult.FAILED_PERMANENT
+            
+            logger.debug(f"Mapped allocation data: {mapped_allocation_data}")
+            
+            from pear_schedule.schemas.ref_patient_allocation import RefPatientAllocationCreate
+            try:
+                ref_allocation_data = RefPatientAllocationCreate(**mapped_allocation_data)
+            except Exception as e:
+                logger.error(f"Failed to create RefPatientAllocationCreate schema: {str(e)}")
+                logger.error(f"Mapped data: {mapped_allocation_data}")
+                return MessageProcessingResult.FAILED_PERMANENT
+            
+            result, was_duplicate = self.create_ref_patient_allocation(
+                db=db,
+                allocation=ref_allocation_data,
+                correlation_id=correlation_id,
+                created_by=created_by
+            )
+            
+            if was_duplicate:
+                logger.info(f"Duplicate creation event for allocation {allocation_id}")
+                return MessageProcessingResult.DUPLICATE
+            
+            if result:
+                logger.info(f"Successfully created allocation {allocation_id}")
+                return MessageProcessingResult.SUCCESS
+            else:
+                logger.error(f"Failed to create allocation {allocation_id}")
+                return MessageProcessingResult.FAILED_RETRYABLE
+            
+        except ValueError as e:
+            logger.warning(f"Business logic error creating allocation: {str(e)}")
+            return MessageProcessingResult.FAILED_PERMANENT
+        except Exception as e:
+            logger.error(f"Error handling allocation creation: {str(e)}")
+            import traceback
+            logger.error(f"Full traceback: {traceback.format_exc()}")
+            return MessageProcessingResult.FAILED_RETRYABLE
+    
+    def _handle_patient_allocation_updated(
+        self, 
+        db, 
+        message_data: Dict[str, Any]
+    ) -> MessageProcessingResult:
+        """Handle patient allocation update events"""
+        try:
+            correlation_id = message_data['correlation_id']
+            allocation_id = message_data['allocation_id']
+            allocation_data = message_data.get('new_data', {})
+            modified_by = message_data.get('modified_by', 'patient_service')
+            is_sync_event = message_data.get('is_sync_event', False)
+            
+            logger.info(f"Handling allocation update for allocation {allocation_id}")
+            
+            mapped_update_data = self.map_patient_allocation_update(allocation_data)
+            if not mapped_update_data:
+                logger.error(
+                    f"Failed to map allocation update data for allocation {allocation_id}"
+                )
+                logger.debug(f"Source update data: {allocation_data}")
+                return MessageProcessingResult.FAILED_PERMANENT
+            
+            logger.debug(f"Mapped update data: {mapped_update_data}")
+            
+            from pear_schedule.schemas.ref_patient_allocation import RefPatientAllocationUpdate
+            try:
+                ref_allocation_update = RefPatientAllocationUpdate(**mapped_update_data)
+            except Exception as e:
+                logger.error(f"Failed to create RefPatientAllocationUpdate schema: {str(e)}")
+                logger.error(f"Mapped data: {mapped_update_data}")
+                return MessageProcessingResult.FAILED_PERMANENT
+            
+            result, was_duplicate = self.update_ref_patient_allocation(
+                db=db,
+                allocation_id=allocation_id,
+                allocation_update=ref_allocation_update,
+                correlation_id=correlation_id,
+                skip_duplicate_check=is_sync_event
+            )
+            
+            if was_duplicate and not is_sync_event:
+                logger.info(f"Duplicate update event for allocation {allocation_id}")
+                return MessageProcessingResult.DUPLICATE
+            
+            if result is None:
+                if is_sync_event:
+                    logger.warning(
+                        f"Allocation {allocation_id} not found during sync - "
+                        "attempting to create"
+                    )
+                    try:
+                        from pear_schedule.schemas.ref_patient_allocation import (
+                            RefPatientAllocationCreate
+                        )
+                        mapped_allocation_data = self.map_patient_allocation_create(
+                            allocation_data
+                        )
+                        if mapped_allocation_data:
+                            ref_allocation_data = RefPatientAllocationCreate(
+                                **mapped_allocation_data
+                            )
+                            create_result, _ = self.create_ref_patient_allocation(
+                                db=db,
+                                allocation=ref_allocation_data,
+                                correlation_id=correlation_id,
+                                created_by=modified_by
+                            )
+                            if create_result:
+                                logger.info(
+                                    f"Successfully created allocation {allocation_id} "
+                                    "during sync"
+                                )
+                                return MessageProcessingResult.SUCCESS
+                    except Exception as e:
+                        logger.error(f"Failed to create allocation during sync: {str(e)}")
+                        return MessageProcessingResult.FAILED_RETRYABLE
+                else:
+                    logger.warning(f"Allocation {allocation_id} not found for update")
+                return MessageProcessingResult.SUCCESS
+            
+            logger.info(f"Successfully updated allocation {allocation_id}")
+            return MessageProcessingResult.SUCCESS
+            
+        except Exception as e:
+            logger.error(f"Error handling allocation update: {str(e)}")
+            import traceback
+            logger.error(f"Full traceback: {traceback.format_exc()}")
+            return MessageProcessingResult.FAILED_RETRYABLE
+    
+    def _handle_patient_allocation_deleted(
+        self, 
+        db, 
+        message_data: Dict[str, Any]
+    ) -> MessageProcessingResult:
+        """Handle patient allocation deletion events"""
+        try:
+            correlation_id = message_data['correlation_id']
+            allocation_id = message_data['allocation_id']
+            updated_datetime = message_data.get('timestamp')
+            deleted_by = message_data.get('deleted_by', 'patient_service')
+            is_sync_event = message_data.get('is_sync_event', False)
+            
+            logger.info(f"Handling allocation deletion for allocation {allocation_id}")
+            
+            from pear_schedule.schemas.ref_patient_allocation import RefPatientAllocationDelete
+            
+            try:
+                if is_sync_event:
+                    updated_datetime = datetime.now()
+                    logger.debug(f"Sync event - forcing timestamp update to {updated_datetime}")
+                
+                ref_allocation_delete = RefPatientAllocationDelete(
+                    modified_date=updated_datetime if updated_datetime else datetime.now(),
+                    modified_by_id=deleted_by
+                )
+                
+            except Exception as e:
+                logger.error(f"Pydantic validation failed: {str(e)}")
+                logger.error(
+                    f"Raw data - modified_date: {updated_datetime}, "
+                    f"modified_by_id: {deleted_by}"
+                )
+                return MessageProcessingResult.FAILED_PERMANENT
+            
+            result, was_duplicate = self.delete_ref_patient_allocation(
+                db=db,
+                allocation_id=allocation_id,
+                allocation_delete=ref_allocation_delete,
+                correlation_id=correlation_id,
+                skip_duplicate_check=is_sync_event
+            )
+            
+            if was_duplicate and not is_sync_event:
+                logger.info(f"Duplicate deletion event for allocation {allocation_id}")
+                return MessageProcessingResult.DUPLICATE
+            
+            if result is None:
+                logger.warning(f"Allocation {allocation_id} not found for deletion")
+                
+            logger.info(f"Successfully processed deletion for allocation {allocation_id}")
+            return MessageProcessingResult.SUCCESS
+            
+        except Exception as e:
+            logger.error(f"Error handling allocation deletion: {str(e)}")
+            import traceback
+            logger.error(f"Full traceback: {traceback.format_exc()}")
+            return MessageProcessingResult.FAILED_RETRYABLE
+    
+    def get_health_status(self) -> Dict[str, Any]:
+        """Get health status for monitoring."""
+        try:
+            return {
+                "status": "healthy",
+                "service": "patient_allocation_consumer",
+                "is_consuming": self.is_consuming,
+                "queues": self.allocation_queues,
+                "rabbitmq_connected": self.client.is_connected() if self.client else False
+            }
+        except Exception as e:
+            return {
+                "status": "unhealthy",
+                "error": str(e)
+            }
+    
+    def close(self):
+        """Close connections"""
+        if self.client:
+            self.client.close()
+            logger.info("Scheduler patient allocation consumer connections closed")

--- a/pear_schedule/api/integrity_router.py
+++ b/pear_schedule/api/integrity_router.py
@@ -1,16 +1,21 @@
-from fastapi import APIRouter, Query, Depends, HTTPException
-from sqlalchemy.orm import Session
-from sqlalchemy import func
 from datetime import datetime, timedelta
 from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
 from pear_schedule.database import get_db
-from pear_schedule.models.ref_activity_model import RefActivity
-from pear_schedule.models.ref_centre_activity_model import RefCentreActivity
 from pear_schedule.models.ref_activity_exclusion_model import RefActivityExclusion
+from pear_schedule.models.ref_activity_model import RefActivity
 from pear_schedule.models.ref_activity_preference_model import RefActivityPreference
-from pear_schedule.models.ref_activity_recommendation_model import RefActivityRecommendation
-from pear_schedule.models.ref_patient_model import RefPatient
+from pear_schedule.models.ref_activity_recommendation_model import (
+    RefActivityRecommendation,
+)
+from pear_schedule.models.ref_centre_activity_model import RefCentreActivity
+from pear_schedule.models.ref_patient_allocation_model import RefPatientAllocation
 from pear_schedule.models.ref_patient_medication_model import RefPatientMedication
+from pear_schedule.models.ref_patient_model import RefPatient
 
 router = APIRouter(tags=["Integrity"])
 
@@ -422,6 +427,68 @@ async def get_ref_patient_medication_integrity(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Ref medication integrity check failed: {str(e)}")
 
+@router.get("/ref-patient-allocation")
+async def get_ref_patient_allocation_integrity(
+    hours_back: int = Query(1, ge=1, le=168),
+    patient_id: Optional[int] = Query(None, description="Filter by specific patient"),
+    limit: int = Query(1000, ge=1, le=5000),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db)
+):
+    """
+    Returns reference patient allocation IDs and timestamps.
+    This data should match the authoritative Patient Service.
+    """
+    try:
+        
+        cutoff_time = datetime.now() - timedelta(hours=hours_back)
+        
+        query = db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.modified_date >= cutoff_time
+        )
+        
+        if patient_id:
+            query = query.filter(RefPatientAllocation.patientId == patient_id)
+        
+        ref_allocations = query.order_by(
+            RefPatientAllocation.id
+        ).limit(limit).offset(offset).all()
+        
+        records = []
+        for allocation in ref_allocations:
+            records.append({
+                "PatientAllocationID": allocation.id,
+                "PatientID": allocation.patientId,
+                "modified_date": allocation.modified_date.isoformat(),
+                "version_timestamp": int(allocation.modified_date.timestamp() * 1000),
+                "record_type": "ref_patient_allocation"
+            })
+        
+        count_query = db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.modified_date >= cutoff_time
+        )
+        if patient_id:
+            count_query = count_query.filter(RefPatientAllocation.patientId == patient_id)
+        total_count = count_query.count()
+        
+        return {
+            "service": "scheduler",
+            "endpoint": "/integrity/ref-patient-allocation",
+            "window_hours": hours_back,
+            "cutoff_time": cutoff_time.isoformat(),
+            "patient_filter": patient_id,
+            "total_count": total_count,
+            "returned_count": len(records),
+            "limit": limit,
+            "offset": offset,
+            "has_more": (offset + len(records)) < total_count,
+            "records": records,
+            "generated_at": datetime.now().isoformat(),
+            "note": "eventual_consistent_copy"
+        }
+        
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Ref patient allocation integrity check failed: {str(e)}")
 
 @router.get("/summary")
 async def get_ref_integrity_summary(
@@ -464,8 +531,12 @@ async def get_ref_integrity_summary(
             RefPatientMedication.UpdatedDateTime >= cutoff_time
         ).count()
         
+        allocation_count = db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.modified_date >= cutoff_time
+        ).count()
+        
         total = (activity_count + centre_activity_count + preference_count + 
-                recommendation_count + exclusion_count + patient_count + medication_count)
+                recommendation_count + exclusion_count + patient_count + medication_count + allocation_count)
         
         return {
             "service": "scheduler",
@@ -480,6 +551,7 @@ async def get_ref_integrity_summary(
                 "ref_centre_activity_exclusion": exclusion_count,
                 "ref_patient": patient_count,
                 "ref_patient_medication": medication_count,
+                "ref_patient_allocation": allocation_count,
                 "total": total
             },
             "generated_at": datetime.now().isoformat(),

--- a/pear_schedule/crud/ref_patient_allocation_crud.py
+++ b/pear_schedule/crud/ref_patient_allocation_crud.py
@@ -1,0 +1,415 @@
+import logging
+import math
+from typing import List, Optional, Tuple
+
+from sqlalchemy import func, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from pear_schedule.models.processed_events_model import ProcessedEvent
+from pear_schedule.models.ref_patient_allocation_model import RefPatientAllocation
+from pear_schedule.schemas.ref_patient_allocation import (
+    RefPatientAllocationCreate,
+    RefPatientAllocationDelete,
+    RefPatientAllocationUpdate,
+)
+from pear_schedule.services.idempotency_service import IdempotencyService
+
+logger = logging.getLogger(__name__)
+
+
+def create_ref_patient_allocation(
+    db: Session,
+    allocation: RefPatientAllocationCreate,
+    correlation_id: str,
+    created_by: str
+) -> Tuple[RefPatientAllocation, bool]:
+    """
+    Create a new patient allocation with idempotency protection.
+    
+    Args:
+        db: Database session
+        allocation: Patient allocation data to create
+        correlation_id: Correlation ID from outbox service for deduplication
+        created_by: User/service creating the allocation
+        
+    Returns:
+        Tuple of (RefPatientAllocation, was_duplicate: bool)
+        
+    Raises:
+        ValueError: If allocation with same ID already exists (business logic error)
+        Exception: For database or other errors
+    """
+    
+    def create_operation():
+        # Check if allocation already exists - this is a business rule violation for CREATE
+        existing = db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.id == allocation.id
+        ).first()
+        if existing:
+            raise ValueError(
+                f"Patient allocation with ID {allocation.id} already exists. "
+                "Use update operation instead."
+            )
+        
+        logger.info(
+            f"Creating new patient allocation {allocation.id} "
+            f"for patient {allocation.patient_id}"
+        )
+        
+        # Use raw SQL for IDENTITY INSERT to handle specific ID
+        query = text("""
+            SET IDENTITY_INSERT [REF_PATIENT_ALLOCATION] ON;
+            
+            INSERT INTO [REF_PATIENT_ALLOCATION] (
+                id, active, isDeleted, patientId, doctorId, gameTherapistId, supervisorId, 
+                caregiverId, tempDoctorId, tempCaregiverId,
+                created_date, modified_date, created_by_id, modified_by_id
+            ) VALUES (
+                :id, :active, :isDeleted, :patientId, :doctorId, :gameTherapistId, :supervisorId,
+                :caregiverId, :tempDoctorId, :tempCaregiverId,
+                :created_date, :modified_date, :created_by_id, :modified_by_id
+            );
+            
+            SET IDENTITY_INSERT [REF_PATIENT_ALLOCATION] OFF;
+        """)
+        
+        params = {
+            "id": allocation.id,
+            "active": allocation.active,
+            "isDeleted": allocation.is_deleted or "0",
+            "patientId": allocation.patient_id,
+            "doctorId": allocation.doctor_id,
+            "gameTherapistId": allocation.game_therapist_id,
+            "supervisorId": allocation.supervisor_id,
+            "caregiverId": allocation.caregiver_id,
+            "tempDoctorId": allocation.temp_doctor_id,
+            "tempCaregiverId": allocation.temp_caregiver_id,
+            "created_date": allocation.created_date,
+            "modified_date": allocation.modified_date,
+            "created_by_id": created_by,
+            "modified_by_id": created_by,
+        }
+        
+        db.execute(query, params)
+        db.flush()
+        
+        # Return the created allocation
+        created_allocation = db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.id == allocation.id
+        ).first()
+        if not created_allocation:
+            raise Exception(f"Failed to create patient allocation {allocation.id}")
+            
+        return created_allocation
+    
+    # Use IdempotencyService for deduplication
+    try:
+        result, was_duplicate = IdempotencyService.process_idempotent(
+            db=db,
+            correlation_id=correlation_id,
+            event_type="PATIENT_ALLOCATION_CREATED",
+            aggregate_id=str(allocation.id),
+            processed_by=f"scheduler_service_{created_by}",
+            operation=create_operation
+        )
+        
+        if was_duplicate:
+            # Return existing allocation for duplicate events
+            existing_allocation = db.query(RefPatientAllocation).filter(
+                RefPatientAllocation.id == allocation.id
+            ).first()
+            logger.info(
+                f"Duplicate create event for patient allocation {allocation.id}, "
+                "returning existing"
+            )
+            return existing_allocation, True
+        
+        db.commit()
+        logger.info(
+            f"Successfully created patient allocation {allocation.id} "
+            f"for patient {allocation.patient_id}"
+        )
+        return result, False
+        
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error creating patient allocation {allocation.id}: {str(e)}")
+        raise
+
+
+def update_ref_patient_allocation(
+    db: Session,
+    allocation_id: str,
+    allocation_update: RefPatientAllocationUpdate,
+    correlation_id: str,
+    skip_duplicate_check: bool = False
+) -> Tuple[Optional[RefPatientAllocation], bool]:
+    """
+    Update an existing patient allocation with idempotency protection.
+    
+    Args:
+        db: Database session
+        allocation_id: ID of allocation to update
+        allocation_update: Fields to update (includes modified_date and modified_by_id)
+        correlation_id: Correlation ID from outbox service for deduplication
+        skip_duplicate_check: If True, bypass idempotency check (for sync events)
+        
+    Returns:
+        Tuple of (RefPatientAllocation or None, was_duplicate: bool)
+        None if allocation not found
+        
+    Raises:
+        Exception: For database or other errors
+    """
+    
+    def update_operation():
+        # Find the allocation to update
+        db_allocation = db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.id == allocation_id,
+            RefPatientAllocation.isDeleted == "0"
+        ).first()
+        
+        if not db_allocation:
+            logger.warning(f"Patient allocation {allocation_id} not found for update")
+            return None
+        
+        logger.debug(f"Updating patient allocation {allocation_id}")
+        
+        # Update only the fields that were provided
+        update_data = allocation_update.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            # Map schema field names to model field names
+            if field == 'patient_id':
+                setattr(db_allocation, 'patientId', value)
+            elif field == 'doctor_id':
+                setattr(db_allocation, 'doctorId', value)
+            elif field == 'game_therapist_id':
+                setattr(db_allocation, 'gameTherapistId', value)
+            elif field == 'supervisor_id':
+                setattr(db_allocation, 'supervisorId', value)
+            elif field == 'caregiver_id':
+                setattr(db_allocation, 'caregiverId', value)
+            elif field == 'temp_doctor_id':
+                setattr(db_allocation, 'tempDoctorId', value)
+            elif field == 'temp_caregiver_id':
+                setattr(db_allocation, 'tempCaregiverId', value)
+            elif field == 'is_deleted':
+                setattr(db_allocation, 'isDeleted', value)
+            elif field == 'modified_date':
+                setattr(db_allocation, 'modified_date', value)
+            elif field == 'modified_by_id':
+                setattr(db_allocation, 'modified_by_id', value)
+            elif hasattr(db_allocation, field) and field != 'id':  # Never update ID
+                setattr(db_allocation, field, value)
+        
+        db.flush()
+        return db_allocation
+    
+    # Use IdempotencyService for deduplication (unless skipped for sync events)
+    try:
+        if skip_duplicate_check:
+            logger.info(
+                f"Skipping duplicate check for patient allocation {allocation_id} "
+                "(sync event)"
+            )
+            # Execute update directly without idempotency check
+            result = update_operation()
+            was_duplicate = False
+            
+            # Still record the event for tracking, but don't check for duplicates
+            try:
+                IdempotencyService.record_processed_event(
+                    db=db,
+                    correlation_id=correlation_id,
+                    event_type="PATIENT_ALLOCATION_UPDATED",
+                    aggregate_id=allocation_id,
+                    processed_by=f"scheduler_service_{allocation_update.modified_by_id}_sync"
+                )
+            except Exception as e:
+                logger.warning(f"Failed to record sync event (non-critical): {str(e)}")
+        else:
+            result, was_duplicate = IdempotencyService.process_idempotent(
+                db=db,
+                correlation_id=correlation_id,
+                event_type="PATIENT_ALLOCATION_UPDATED",
+                aggregate_id=allocation_id,
+                processed_by=f"scheduler_service_{allocation_update.modified_by_id}",
+                operation=update_operation
+            )
+        
+        if was_duplicate:
+            # Return current state for duplicate events
+            existing_allocation = db.query(RefPatientAllocation).filter(
+                RefPatientAllocation.id == allocation_id,
+                RefPatientAllocation.isDeleted == "0"
+            ).first()
+            logger.info(
+                f"Duplicate update event for patient allocation {allocation_id}, "
+                "returning current state"
+            )
+            return existing_allocation, True
+        
+        if result is None:
+            logger.warning(f"Patient allocation {allocation_id} not found for update")
+            db.commit()  # Commit the idempotency record even if allocation not found
+            return None, False
+        
+        db.commit()
+        logger.debug(f"Successfully updated patient allocation {allocation_id}")
+        return result, False
+        
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error updating patient allocation {allocation_id}: {str(e)}")
+        raise
+
+
+def delete_ref_patient_allocation(
+    db: Session,
+    allocation_id: str,
+    allocation_delete: RefPatientAllocationDelete,
+    correlation_id: str,
+    skip_duplicate_check: bool = False
+) -> Tuple[Optional[RefPatientAllocation], bool]:
+    """
+    Soft delete a patient allocation with idempotency protection.
+    
+    Args:
+        db: Database session
+        allocation_id: ID of allocation to delete
+        allocation_delete: Delete data including timestamp and user info
+        correlation_id: Correlation ID from outbox service for deduplication
+        skip_duplicate_check: If True, bypass idempotency check (for sync events)
+        
+    Returns:
+        Tuple of (RefPatientAllocation or None, was_duplicate: bool)
+        None if allocation not found
+        
+    Raises:
+        Exception: For database or other errors
+    """
+    
+    def delete_operation():
+        # Find the allocation to delete
+        db_allocation = db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.id == allocation_id
+        ).first()
+        
+        if not db_allocation:
+            logger.warning(f"Patient allocation {allocation_id} not found for deletion")
+            return None
+        
+        if db_allocation.isDeleted == "1":
+            logger.info(f"Patient allocation {allocation_id} already deleted")
+            return db_allocation
+        
+        logger.info(f"Soft deleting patient allocation {allocation_id}")
+        
+        # Perform soft delete using schema data
+        db_allocation.isDeleted = "1"
+        db_allocation.modified_by_id = allocation_delete.modified_by_id
+        db_allocation.modified_date = allocation_delete.modified_date
+        
+        db.flush()
+        return db_allocation
+    
+    # Use IdempotencyService for deduplication
+    try:
+        result, was_duplicate = IdempotencyService.process_idempotent(
+            db=db,
+            correlation_id=correlation_id,
+            event_type="PATIENT_ALLOCATION_DELETED",
+            aggregate_id=allocation_id,
+            processed_by=f"scheduler_service_{allocation_delete.modified_by_id}",
+            operation=delete_operation
+        )
+        
+        if was_duplicate:
+            # Return current state for duplicate events
+            existing_allocation = db.query(RefPatientAllocation).filter(
+                RefPatientAllocation.id == allocation_id
+            ).first()
+            logger.info(
+                f"Duplicate delete event for patient allocation {allocation_id}, "
+                "returning current state"
+            )
+            return existing_allocation, True
+        
+        if result is None:
+            logger.warning(f"Patient allocation {allocation_id} not found for deletion")
+            db.commit()  # Commit the idempotency record even if allocation not found
+            return None, False
+        
+        db.commit()
+        logger.info(f"Successfully deleted patient allocation {allocation_id}")
+        return result, False
+        
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error deleting patient allocation {allocation_id}: {str(e)}")
+        raise
+
+
+def get_ref_patient_allocation_by_id(
+    db: Session, 
+    allocation_id: str
+) -> Optional[RefPatientAllocation]:
+    """
+    Get a single patient allocation by ID.
+    
+    Args:
+        db: Database session
+        allocation_id: Allocation ID to find
+        
+    Returns:
+        RefPatientAllocation if found, None otherwise
+    """
+    return db.query(RefPatientAllocation).filter(
+        RefPatientAllocation.id == allocation_id,
+        RefPatientAllocation.isDeleted == "0"
+    ).first()
+
+
+def get_ref_patient_allocation_by_patient_id(
+    db: Session, 
+    patient_id: int
+) -> Optional[RefPatientAllocation]:
+    """
+    Get a patient allocation by patient ID (returns active allocation).
+    
+    Args:
+        db: Database session
+        patient_id: Patient ID to find allocation for
+        
+    Returns:
+        RefPatientAllocation if found, None otherwise
+    """
+    return db.query(RefPatientAllocation).filter(
+        RefPatientAllocation.patientId == patient_id,
+        RefPatientAllocation.active == "Y",
+        RefPatientAllocation.isDeleted == "0"
+    ).first()
+
+
+def check_patient_allocation_exists(db: Session, allocation_id: str) -> bool:
+    """
+    Check if a patient allocation exists (including deleted ones).
+    
+    Args:
+        db: Database session
+        allocation_id: Allocation ID to check
+        
+    Returns:
+        True if allocation exists, False otherwise
+    """
+    count = db.query(func.count(RefPatientAllocation.id)).filter(
+        RefPatientAllocation.id == allocation_id
+    ).scalar()
+    
+    return count > 0
+
+
+def is_event_already_processed(db: Session, correlation_id: str) -> bool:
+    """Check if a specific correlation_id was already processed."""
+    return IdempotencyService.is_already_processed(db, correlation_id)

--- a/pear_schedule/models/ref_patient_allocation_model.py
+++ b/pear_schedule/models/ref_patient_allocation_model.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Integer, String, func
+
+from pear_schedule.database import Base
+
+
+class RefPatientAllocation(Base):
+    __tablename__ = "REF_PATIENT_ALLOCATION"
+
+    id = Column(Integer, primary_key=True, index=True)
+    active = Column(String(1), default='Y', nullable=False)
+    isDeleted = Column(String(1), default='0', nullable=False)
+    patientId = Column(Integer, nullable=False, index=True)
+    doctorId = Column(String, nullable=False)
+    gameTherapistId = Column(String, nullable=False)
+    supervisorId = Column(String, nullable=False)
+    caregiverId = Column(String, nullable=False)
+    tempDoctorId = Column(String)
+    tempCaregiverId = Column(String)
+
+    created_date  = Column("created_date", DateTime, nullable=False,
+                           server_default=func.sysutcdatetime())
+    modified_date = Column("modified_date", DateTime, nullable=False,
+                           server_default=func.sysutcdatetime(),
+                           onupdate=func.sysutcdatetime())
+    created_by_id  = Column("created_by_id", String(50), nullable=True)
+    modified_by_id = Column("modified_by_id", String(50), nullable=True)

--- a/pear_schedule/schemas/ref_patient_allocation.py
+++ b/pear_schedule/schemas/ref_patient_allocation.py
@@ -1,0 +1,59 @@
+from pydantic import BaseModel, Field, ConfigDict
+from datetime import datetime
+from typing import Optional
+
+
+class RefPatientAllocationBase(BaseModel):
+    """Base schema for ref patient allocation with common fields"""
+    patient_id: int = Field(..., description="Patient ID")
+    doctor_id: str = Field(..., max_length=255, description="Doctor ID")
+    game_therapist_id: str = Field(..., max_length=255, description="Game Therapist ID")
+    supervisor_id: str = Field(..., max_length=255, description="Supervisor ID")
+    caregiver_id: str = Field(..., max_length=255, description="Caregiver ID")
+    temp_doctor_id: Optional[str] = Field(None, max_length=255, description="Temporary Doctor ID")
+    temp_caregiver_id: Optional[str] = Field(None, max_length=255, description="Temporary Caregiver ID")
+
+
+class RefPatientAllocationCreate(RefPatientAllocationBase):
+    """Schema for creating a new ref patient allocation - includes id for message queue operations"""
+    id: int = Field(..., description="Patient Allocation ID from source system")
+    active: str = Field(default="Y", pattern="^[YN]$", description="Active status: Y or N")
+    is_deleted: str = Field(default="0", pattern="^[01]$", description="Deletion status: 0 or 1")
+    created_date: datetime = Field(..., description="Creation timestamp")
+    modified_date: datetime = Field(..., description="Last modification timestamp")
+    created_by_id: str = Field(..., max_length=50, description="Creator user/service ID")
+    modified_by_id: str = Field(..., max_length=50, description="Last modifier user/service ID")
+
+
+class RefPatientAllocationUpdate(BaseModel):
+    """Schema for updating an existing ref patient allocation"""
+    patient_id: Optional[int] = None
+    doctor_id: Optional[str] = Field(None, max_length=255)
+    game_therapist_id: Optional[str] = Field(None, max_length=255)
+    supervisor_id: Optional[str] = Field(None, max_length=255)
+    caregiver_id: Optional[str] = Field(None, max_length=255)
+    temp_doctor_id: Optional[str] = Field(None, max_length=255)
+    temp_caregiver_id: Optional[str] = Field(None, max_length=255)
+    active: Optional[str] = Field(None, pattern="^[YN]$")
+    is_deleted: Optional[str] = Field(None, pattern="^[01]$")
+    modified_date: datetime = Field(..., description="Last modification timestamp")
+    modified_by_id: str = Field(..., max_length=50, description="Modifier user/service ID")
+
+
+class RefPatientAllocationDelete(BaseModel):
+    """Schema for soft-deleting a ref patient allocation"""
+    modified_date: datetime = Field(..., description="Deletion timestamp")
+    modified_by_id: str = Field(..., max_length=50, description="Deleter user/service ID")
+
+
+class RefPatientAllocation(RefPatientAllocationBase):
+    """Schema for ref patient allocation response"""
+    id: int
+    active: str = Field(default="Y", pattern="^[YN]$")
+    is_deleted: str = Field(default="0", pattern="^[01]$")
+    created_date: datetime
+    modified_date: datetime
+    created_by_id: str
+    modified_by_id: str
+    
+    model_config = ConfigDict(from_attributes=True)

--- a/tests/integration_tests/test_patient_allocation_consumer_integration.py
+++ b/tests/integration_tests/test_patient_allocation_consumer_integration.py
@@ -1,0 +1,513 @@
+"""
+Integration tests for Scheduler Service Patient Allocation Consumer
+Tests the flow: Message → Patient Allocation Consumer → REF_PATIENT_ALLOCATION table update → PROCESSED_EVENTS tracking
+
+SQL Commands to clear DB:
+DELETE FROM [PROCESSED_EVENTS] WHERE event_type LIKE 'PATIENT_ALLOCATION%';
+DELETE FROM [REF_PATIENT_ALLOCATION];
+"""
+
+import json
+import uuid
+from datetime import datetime
+from typing import Any, Dict
+
+import pytest
+
+from messaging.patient_allocation_consumer import PatientAllocationConsumer
+from pear_schedule.database import SessionLocal
+from pear_schedule.models.processed_events_model import (
+    MessageProcessingResult,
+    ProcessedEvent,
+)
+from pear_schedule.models.ref_patient_allocation_model import RefPatientAllocation
+
+# ===== Database Fixture =====
+
+@pytest.fixture(scope="function")
+def integration_db():
+    """
+    Uses the real database connection from pear_schedule.database.
+    Each test gets a fresh session.
+    """
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def patient_allocation_consumer():
+    """
+    Fixture for PatientAllocationConsumer instance.
+    """
+    consumer = PatientAllocationConsumer()
+    yield consumer
+    # Cleanup
+    if consumer.client:
+        consumer.client.close()
+
+
+@pytest.fixture
+def mock_allocation_data():
+    """
+    Mock patient allocation data matching the Patient Service model
+    """
+    return {
+        'id': 12345,
+        'active': 'Y',
+        'isDeleted': '0',
+        'patientId': 100,
+        'doctorId': 'DOC123',
+        'gameTherapistId': 'GT456',
+        'supervisorId': 'SUP789',
+        'caregiverId': 'CG101',
+        'tempDoctorId': None,
+        'tempCaregiverId': None,
+        'guardianId': 1,
+        'guardian2Id': None,
+        'createdDate': datetime(2024, 1, 1).isoformat(),
+        'modifiedDate': datetime(2024, 1, 1).isoformat(),
+        'CreatedById': 'test-user-1',
+        'ModifiedById': 'test-user-1'
+    }
+
+
+@pytest.fixture(autouse=True)
+def cleanup_test_data(integration_db):
+    """
+    Cleanup fixture that runs after each test.
+    Deletes all test data created during the test.
+    """
+    # This runs BEFORE the test
+    yield
+
+    # This runs AFTER the test - cleanup
+    try:
+        # Delete all processed events for patient allocation
+        integration_db.query(ProcessedEvent).filter(
+            ProcessedEvent.event_type.like('PATIENT_ALLOCATION%')
+        ).delete(synchronize_session=False)
+        integration_db.commit()
+
+        # Delete all ref patient allocations created in tests
+        integration_db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.created_by_id == 'test-user-1'
+        ).delete(synchronize_session=False)
+        integration_db.commit()
+
+        print("\n[CLEANUP] Test data cleared successfully")
+    except Exception as e:
+        integration_db.rollback()
+        print(f"\n[CLEANUP] Warning: Failed to cleanup test data: {str(e)}")
+
+
+# ===== Helper Functions =====
+
+def create_allocation_created_message(allocation_data: Dict[str, Any], 
+                                     correlation_id: str = None) -> Dict[str, Any]:
+    """Helper to create PATIENT_ALLOCATION_CREATED message"""
+    if not correlation_id:
+        correlation_id = str(uuid.uuid4()).upper()
+
+    return {
+        "timestamp": datetime.now().isoformat(),
+        "source_service": "patient-service",
+        "data": {
+            "correlation_id": correlation_id,
+            "event_type": "PATIENT_ALLOCATION_CREATED",
+            "allocation_id": allocation_data["id"],
+            "patient_id": allocation_data["patientId"],
+            "allocation_data": allocation_data,
+            "created_by": allocation_data.get("CreatedById", "test-user-1"),
+            "created_by_name": "Test User",
+            "timestamp": datetime.now().isoformat()
+        }
+    }
+
+
+def create_allocation_updated_message(allocation_id: int, old_data: Dict[str, Any],
+                                     new_data: Dict[str, Any], correlation_id: str = None) -> Dict[str, Any]:
+    """Helper to create PATIENT_ALLOCATION_UPDATED message"""
+    if not correlation_id:
+        correlation_id = str(uuid.uuid4()).upper()
+
+    changes = {}
+    for key in new_data:
+        if key in old_data and old_data[key] != new_data[key]:
+            changes[key] = {"old": old_data[key], "new": new_data[key]}
+
+    return {
+        "timestamp": datetime.now().isoformat(),
+        "source_service": "patient-service",
+        "data": {
+            "correlation_id": correlation_id,
+            "event_type": "PATIENT_ALLOCATION_UPDATED",
+            "allocation_id": allocation_id,
+            "patient_id": new_data["patientId"],
+            "old_data": old_data,
+            "new_data": new_data,
+            "changes": changes,
+            "modified_by": new_data.get("ModifiedById", "test-user-1"),
+            "modified_by_name": "Test User",
+            "timestamp": datetime.now().isoformat()
+        }
+    }
+
+
+def create_allocation_deleted_message(allocation_id: int, allocation_data: Dict[str, Any],
+                                      correlation_id: str = None) -> Dict[str, Any]:
+    """Helper to create PATIENT_ALLOCATION_DELETED message"""
+    if not correlation_id:
+        correlation_id = str(uuid.uuid4()).upper()
+
+    return {
+        "timestamp": datetime.now().isoformat(),
+        "source_service": "patient-service",
+        "data": {
+            "correlation_id": correlation_id,
+            "event_type": "PATIENT_ALLOCATION_DELETED",
+            "allocation_id": allocation_id,
+            "patient_id": allocation_data["patientId"],
+            "allocation_data": allocation_data,
+            "deleted_by": "test-user-1",
+            "deleted_by_name": "Test User",
+            "timestamp": datetime.now().isoformat()
+        }
+    }
+
+
+# ===== Create Patient Allocation Tests =====
+
+class TestConsumerPatientAllocationCreate:
+    """Test consumer processing of PATIENT_ALLOCATION_CREATED events"""
+
+    def test_create_allocation_processes_message_successfully(self, integration_db, 
+                                                              patient_allocation_consumer,
+                                                              mock_allocation_data):
+        """
+        GIVEN: PATIENT_ALLOCATION_CREATED message
+        WHEN: Consumer processes the message
+        THEN: REF_PATIENT_ALLOCATION record is created and PROCESSED_EVENTS record exists
+
+        Goal: Verify that consuming a PATIENT_ALLOCATION_CREATED message creates the allocation
+        """
+        correlation_id = str(uuid.uuid4()).upper()
+        message = create_allocation_created_message(mock_allocation_data, correlation_id)
+
+        print(f"\nProcessing PATIENT_ALLOCATION_CREATED message with correlation_id: {correlation_id}")
+
+        # Process the message
+        result = patient_allocation_consumer._process_patient_allocation_message(message)
+
+        print(f"Processing result: {result}")
+
+        # Verify processing result
+        assert result == MessageProcessingResult.SUCCESS
+
+        # Verify REF_PATIENT_ALLOCATION record created
+        ref_allocation = integration_db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.id == mock_allocation_data["id"]
+        ).first()
+
+        assert ref_allocation is not None
+        assert ref_allocation.patientId == mock_allocation_data["patientId"]
+        assert ref_allocation.doctorId == mock_allocation_data["doctorId"]
+        assert ref_allocation.gameTherapistId == mock_allocation_data["gameTherapistId"]
+        assert ref_allocation.supervisorId == mock_allocation_data["supervisorId"]
+        assert ref_allocation.caregiverId == mock_allocation_data["caregiverId"]
+        assert ref_allocation.active == "Y"
+        assert ref_allocation.isDeleted == "0"
+
+        print(f"DONE: Created REF_PATIENT_ALLOCATION ID: {ref_allocation.id}")
+        print(f"  Patient ID: {ref_allocation.patientId}")
+        print(f"  Doctor ID: {ref_allocation.doctorId}")
+        print(f"  IsDeleted: {ref_allocation.isDeleted}")
+
+        # Verify PROCESSED_EVENTS record created
+        processed_event = integration_db.query(ProcessedEvent).filter(
+            ProcessedEvent.correlation_id == correlation_id
+        ).first()
+
+        assert processed_event is not None
+        assert processed_event.event_type == "PATIENT_ALLOCATION_CREATED"
+        assert processed_event.aggregate_id == str(mock_allocation_data["id"])
+        assert json.loads(processed_event.operation_result)['status'] == "success"
+
+        print(f"DONE: Created PROCESSED_EVENT ID: {processed_event.aggregate_id}")
+        print(f"  Event Type: {processed_event.event_type}")
+        print(f"  Status: {json.loads(processed_event.operation_result)['status']}")
+
+    def test_duplicate_create_message_is_idempotent(self, integration_db, 
+                                                    patient_allocation_consumer, 
+                                                    mock_allocation_data):
+        """
+        GIVEN: PATIENT_ALLOCATION_CREATED message processed twice with same correlation_id
+        WHEN: Consumer processes duplicate message
+        THEN: Returns DUPLICATE result and no additional records created
+
+        Goal: Verify idempotency - duplicate messages don't create duplicate records
+        """
+        correlation_id = str(uuid.uuid4()).upper()
+        message = create_allocation_created_message(mock_allocation_data, correlation_id)
+
+        print(f"\nProcessing initial PATIENT_ALLOCATION_CREATED message: {correlation_id}")
+
+        # Process first time
+        result1 = patient_allocation_consumer._process_patient_allocation_message(message)
+        assert result1 == MessageProcessingResult.SUCCESS
+
+        initial_allocation_count = integration_db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.id == mock_allocation_data["id"]
+        ).count()
+        initial_processed_count = integration_db.query(ProcessedEvent).filter(
+            ProcessedEvent.correlation_id == correlation_id
+        ).count()
+
+        print(f"Initial counts - Allocations: {initial_allocation_count}, Processed Events: {initial_processed_count}")
+
+        # Process duplicate message
+        print(f"Processing duplicate PATIENT_ALLOCATION_CREATED message: {correlation_id}")
+        result2 = patient_allocation_consumer._process_patient_allocation_message(message)
+
+        # Should return DUPLICATE
+        assert result2 == MessageProcessingResult.DUPLICATE
+
+        # Verify no additional records created
+        final_allocation_count = integration_db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.id == mock_allocation_data["id"]
+        ).count()
+        final_processed_count = integration_db.query(ProcessedEvent).filter(
+            ProcessedEvent.correlation_id == correlation_id
+        ).count()
+
+        assert final_allocation_count == initial_allocation_count
+        assert final_processed_count == initial_processed_count
+
+        print(f"DONE: Duplicate message handled correctly - no new records created")
+        print(f"Final counts - Allocations: {final_allocation_count}, Processed Events: {final_processed_count}")
+
+
+# ===== Update Patient Allocation Tests =====
+
+class TestConsumerPatientAllocationUpdate:
+    """Test consumer processing of PATIENT_ALLOCATION_UPDATED events"""
+
+    def test_update_allocation_processes_message_successfully(self, integration_db,
+                                                              patient_allocation_consumer,
+                                                              mock_allocation_data):
+        """
+        GIVEN: Existing REF_PATIENT_ALLOCATION record and PATIENT_ALLOCATION_UPDATED message
+        WHEN: Consumer processes the message
+        THEN: REF_PATIENT_ALLOCATION record is updated and PROCESSED_EVENTS record exists
+
+        Goal: Verify that consuming a PATIENT_ALLOCATION_UPDATED message updates the allocation
+        """
+        # First create the allocation
+        create_correlation_id = str(uuid.uuid4()).upper()
+        create_message = create_allocation_created_message(mock_allocation_data, create_correlation_id)
+        patient_allocation_consumer._process_patient_allocation_message(create_message)
+
+        print(f"\nCreated initial allocation ID: {mock_allocation_data['id']}")
+
+        # Clear processed events for clean test
+        integration_db.query(ProcessedEvent).filter(
+            ProcessedEvent.correlation_id == create_correlation_id
+        ).delete()
+        integration_db.commit()
+
+        # Update the allocation
+        updated_data = mock_allocation_data.copy()
+        updated_data["doctorId"] = "DOC999"
+        updated_data["caregiverId"] = "CG999"
+        updated_data["modifiedDate"] = datetime.now().isoformat()
+
+        update_correlation_id = str(uuid.uuid4()).upper()
+        update_message = create_allocation_updated_message(
+            mock_allocation_data["id"],
+            mock_allocation_data,
+            updated_data,
+            update_correlation_id
+        )
+
+        print(f"Processing PATIENT_ALLOCATION_UPDATED message: {update_correlation_id}")
+
+        # Process update message
+        result = patient_allocation_consumer._process_patient_allocation_message(update_message)
+
+        # Verify processing result
+        assert result == MessageProcessingResult.SUCCESS
+
+        # Verify REF_PATIENT_ALLOCATION record updated
+        ref_allocation = integration_db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.id == mock_allocation_data["id"]
+        ).first()
+
+        assert ref_allocation is not None
+        assert ref_allocation.doctorId == "DOC999"
+        assert ref_allocation.caregiverId == "CG999"
+        assert ref_allocation.isDeleted == "0"
+
+        print(f"DONE: Updated REF_PATIENT_ALLOCATION ID: {ref_allocation.id}")
+        print(f"  New Doctor ID: {ref_allocation.doctorId}")
+        print(f"  New Caregiver ID: {ref_allocation.caregiverId}")
+
+        # Verify PROCESSED_EVENTS record created
+        processed_event = integration_db.query(ProcessedEvent).filter(
+            ProcessedEvent.correlation_id == update_correlation_id
+        ).first()
+
+        assert processed_event is not None
+        assert processed_event.event_type == "PATIENT_ALLOCATION_UPDATED"
+        assert processed_event.aggregate_id == str(mock_allocation_data["id"])
+
+        print(f"DONE: Created PROCESSED_EVENT ID: {processed_event.aggregate_id}")
+
+    def test_update_nonexistent_allocation_succeeds_gracefully(self, integration_db,
+                                                               patient_allocation_consumer,
+                                                               mock_allocation_data):
+        """
+        GIVEN: PATIENT_ALLOCATION_UPDATED message for non-existent allocation
+        WHEN: Consumer processes the message
+        THEN: Returns SUCCESS and PROCESSED_EVENTS record created (graceful handling)
+
+        Goal: Verify that updates for non-existent allocations don't cause failures
+        """
+        correlation_id = str(uuid.uuid4()).upper()
+
+        non_existent_data = {**mock_allocation_data, "id": 99999}
+
+        update_message = create_allocation_updated_message(
+            99999,
+            non_existent_data,
+            non_existent_data,
+            correlation_id
+        )
+
+        print(f"\nProcessing UPDATE for non-existent allocation 99999")
+
+        # Process the message
+        result = patient_allocation_consumer._process_patient_allocation_message(update_message)
+
+        # Should succeed gracefully (no crash/retry)
+        assert result == MessageProcessingResult.SUCCESS
+
+        # Verify PROCESSED_EVENTS record created (for idempotency tracking)
+        processed_event = integration_db.query(ProcessedEvent).filter(
+            ProcessedEvent.correlation_id == correlation_id
+        ).first()
+
+        assert processed_event is not None
+
+        print(f"DONE: Non-existent allocation update handled gracefully")
+        print(f"PROCESSED_EVENT created for tracking: {processed_event.aggregate_id}")
+
+
+# ===== Delete Patient Allocation Tests =====
+
+class TestConsumerPatientAllocationDelete:
+    """Test consumer processing of PATIENT_ALLOCATION_DELETED events"""
+
+    def test_delete_allocation_processes_message_successfully(self, integration_db,
+                                                              patient_allocation_consumer,
+                                                              mock_allocation_data):
+        """
+        GIVEN: Existing REF_PATIENT_ALLOCATION record and PATIENT_ALLOCATION_DELETED message
+        WHEN: Consumer processes the message
+        THEN: REF_PATIENT_ALLOCATION record is soft-deleted and PROCESSED_EVENTS record exists
+
+        Goal: Verify that consuming a PATIENT_ALLOCATION_DELETED message soft-deletes the allocation
+        """
+        # First create the allocation
+        create_correlation_id = str(uuid.uuid4()).upper()
+        mock_allocation_data["id"] = 12346  # Unique ID for this test
+        create_message = create_allocation_created_message(mock_allocation_data, create_correlation_id)
+        patient_allocation_consumer._process_patient_allocation_message(create_message)
+
+        print(f"\nCreated initial allocation ID: {mock_allocation_data['id']}")
+
+        # Verify allocation exists and is not deleted
+        allocation_before = integration_db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.id == mock_allocation_data["id"]
+        ).first()
+        assert allocation_before.isDeleted == "0"
+        print(f"Allocation before delete - IsDeleted: {allocation_before.isDeleted}")
+
+        # Delete the allocation
+        delete_correlation_id = str(uuid.uuid4()).upper()
+        delete_message = create_allocation_deleted_message(
+            mock_allocation_data["id"],
+            mock_allocation_data,
+            delete_correlation_id
+        )
+
+        print(f"Processing PATIENT_ALLOCATION_DELETED message: {delete_correlation_id}")
+
+        # Process delete message
+        result = patient_allocation_consumer._process_patient_allocation_message(delete_message)
+
+        # Verify processing result
+        assert result == MessageProcessingResult.SUCCESS
+
+        # Verify REF_PATIENT_ALLOCATION record soft-deleted
+        ref_allocation = integration_db.query(RefPatientAllocation).filter(
+            RefPatientAllocation.id == mock_allocation_data["id"]
+        ).first()
+
+        integration_db.refresh(ref_allocation)
+
+        assert ref_allocation is not None
+        assert ref_allocation.isDeleted == "1"
+
+        print(f"DONE: Soft-deleted REF_PATIENT_ALLOCATION ID: {ref_allocation.id}")
+        print(f"  IsDeleted: {ref_allocation.isDeleted}")
+
+        # Verify PROCESSED_EVENTS record created
+        processed_event = integration_db.query(ProcessedEvent).filter(
+            ProcessedEvent.correlation_id == delete_correlation_id
+        ).first()
+
+        assert processed_event is not None
+        assert processed_event.event_type == "PATIENT_ALLOCATION_DELETED"
+        assert processed_event.aggregate_id == str(mock_allocation_data["id"])
+
+        print(f"DONE: Created PROCESSED_EVENT ID: {processed_event.aggregate_id}")
+
+    def test_delete_nonexistent_allocation_succeeds_gracefully(self, integration_db,
+                                                               patient_allocation_consumer,
+                                                               mock_allocation_data):
+        """
+        GIVEN: PATIENT_ALLOCATION_DELETED message for non-existent allocation
+        WHEN: Consumer processes the message
+        THEN: Returns SUCCESS and PROCESSED_EVENTS record created (graceful handling)
+
+        Goal: Verify that deletes for non-existent allocations don't cause failures
+        """
+        correlation_id = str(uuid.uuid4()).upper()
+
+        non_existent_data = {**mock_allocation_data, "id": 99999}
+
+        delete_message = create_allocation_deleted_message(
+            99999,
+            non_existent_data,
+            correlation_id
+        )
+
+        print(f"\nProcessing DELETE for non-existent allocation 99999")
+
+        # Process the message
+        result = patient_allocation_consumer._process_patient_allocation_message(delete_message)
+
+        # Should succeed gracefully
+        assert result == MessageProcessingResult.SUCCESS
+
+        # Verify PROCESSED_EVENTS record created
+        processed_event = integration_db.query(ProcessedEvent).filter(
+            ProcessedEvent.correlation_id == correlation_id
+        ).first()
+
+        assert processed_event is not None
+
+        print(f"DONE: Non-existent allocation deletion handled gracefully")
+        print(f"PROCESSED_EVENT created for tracking: {processed_event.aggregate_id}")


### PR DESCRIPTION
This PR aims to implement a MQ instance between Patient and Scheduler for the Patient Allocation table. This is needed to aid in implementing medication scheduler, where the caregiver ID of the assigned caregiver (primary caregiver is the assigned medication administer) is taken from Patient Allocation.