### PR TITLE
Fix expired individual activities being scheduled (EndDate filter)

### DIFF
--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -93,7 +93,8 @@ class ActivitiesView(BaseView):
             centre_activity.c["IsGroup"] == False,
             centre_activity.c["IsDeleted"] == False,
             centre_activity.c["StartDate"] < get_monday(),
-            centre_activity.c["IsCompulsory"] == False
+            centre_activity.c["IsCompulsory"] == False,
+            centre_activity.c["EndDate"] > get_next_sunday()
         )
 
         return query


### PR DESCRIPTION
Adds EndDate > get_next_sunday() condition to ActivitiesView to prevent expired individual activities from being included in schedule generation.

Verified locally that expired lunch activity is no longer scheduled.