### PR TITLE
add identity insert settings to create operation

### DIFF
--- a/pear_schedule/crud/ref_patient_allocation_crud.py
+++ b/pear_schedule/crud/ref_patient_allocation_crud.py
@@ -57,8 +57,10 @@ def create_ref_patient_allocation(
             f"for patient {allocation.patient_id}"
         )
         
-        # Use raw SQL to insert with explicit ID (table does not use IDENTITY property)
+        # Use raw SQL to insert with explicit ID, temporarily enabling IDENTITY_INSERT
         query = text("""
+            SET IDENTITY_INSERT [REF_PATIENT_ALLOCATION] ON;
+            
             INSERT INTO [REF_PATIENT_ALLOCATION] (
                 id, active, isDeleted, patientId, doctorId, gameTherapistId, supervisorId,
                 caregiverId, tempDoctorId, tempCaregiverId,
@@ -67,7 +69,9 @@ def create_ref_patient_allocation(
                 :id, :active, :isDeleted, :patientId, :doctorId, :gameTherapistId, :supervisorId,
                 :caregiverId, :tempDoctorId, :tempCaregiverId,
                 :created_date, :modified_date, :created_by_id, :modified_by_id
-            )
+            );
+            
+            SET IDENTITY_INSERT [REF_PATIENT_ALLOCATION] OFF;
         """)
         
         params = {


### PR DESCRIPTION
## fix: add IDENTITY_INSERT to REF_PATIENT_ALLOCATION create operation

### Problem
The `create_ref_patient_allocation` CRUD function was attempting to insert an explicit `id` value into `REF_PATIENT_ALLOCATION`, but the table has an IDENTITY constraint on the `id` column, causing the following error:
```
Cannot insert explicit value for identity column in table
'REF_PATIENT_ALLOCATION' when IDENTITY_INSERT is set to OFF. (544)
```

### Root Cause
`REF_PATIENT_ALLOCATION` must mirror the authoritative `PATIENT_ALLOCATION` records from the Patient Service, so `id` values must match. However, the raw SQL insert was missing the `SET IDENTITY_INSERT` statements required to allow explicit ID insertion.

### Fix
Wrapped the `INSERT` statement with `SET IDENTITY_INSERT [REF_PATIENT_ALLOCATION] ON/OFF` within the same query, consistent with how other ref table CRUDs handle this (e.g. `ref_patient_crud.py`).

### Changes
- `pear_schedule/crud/ref_patient_allocation_crud.py`
  - Added `SET IDENTITY_INSERT [REF_PATIENT_ALLOCATION] ON/OFF` around the `INSERT` in `create_operation()`
  - Updated comment to reflect correct reason for using raw SQL