### PR TITLE
Chore/migrate db marcus

### DIFF
--- a/messaging/centre_activity_consumer.py
+++ b/messaging/centre_activity_consumer.py
@@ -3,14 +3,16 @@ import threading
 import json
 from typing import Dict, Any, Optional
 from datetime import datetime
+from datetime import timedelta
 from contextlib import contextmanager
 
 from .rabbitmq_client import RabbitMQClient
 from pear_schedule.models.processed_events_model import MessageProcessingResult
+from pear_schedule.utils import ConfigDependant
 
 logger = logging.getLogger(__name__)
 
-class CentreActivityConsumer:
+class CentreActivityConsumer(ConfigDependant):
     """
     Consumer for centre activity events with separated CRUD operations.
     
@@ -247,6 +249,8 @@ class CentreActivityConsumer:
                 return MessageProcessingResult.FAILED_PERMANENT
             
             logger.debug(f"Mapped centre activity data: {mapped_centre_activity_data}")
+
+            mapped_centre_activity_data['FixedTimeSlots'] = self.reformat_timeslots(mapped_centre_activity_data['FixedTimeSlots'])
             
             from pear_schedule.schemas.ref_centre_activity import RefCentreActivityCreate
             try:
@@ -301,6 +305,8 @@ class CentreActivityConsumer:
                 return MessageProcessingResult.FAILED_PERMANENT
             
             logger.debug(f"Mapped update data: {mapped_update_data}")
+
+            mapped_update_data['FixedTimeSlots'] = self.reformat_timeslots(mapped_update_data['FixedTimeSlots'])
             
             from pear_schedule.schemas.ref_centre_activity import RefCentreActivityUpdate
             try:
@@ -331,6 +337,7 @@ class CentreActivityConsumer:
                         from pear_schedule.schemas.ref_centre_activity import RefCentreActivityCreate
                         mapped_centre_activity_data = self.map_centre_activity_create(centre_activity_data)
                         if mapped_centre_activity_data:
+                            mapped_centre_activity_data['FixedTimeSlots'] = self.reformat_timeslots(mapped_centre_activity_data['FixedTimeSlots'])
                             ref_centre_activity_data = RefCentreActivityCreate(**mapped_centre_activity_data)
                             create_result, _ = self.create_ref_centre_activity(
                                 db=db,
@@ -430,3 +437,16 @@ class CentreActivityConsumer:
         if self.client:
             self.client.close()
             logger.info("Scheduler centre activity consumer connections closed")
+    
+    def reformat_timeslots(self, timeslot_str: str) -> str:
+        timeslot_list_tmp = timeslot_str.split(",")
+        for i, timeslot_str in enumerate(timeslot_list_tmp):
+            qualified_day = timeslot_str.split(" ")[0]
+            day = self.config['OPEN_DAYS'].index(qualified_day)
+            time_obj = datetime.strptime(timeslot_str.split(" ")[1], "%H:%M")
+            opening_time_obj = datetime.strptime(self.config['WORKING_HOURS'].get(qualified_day.lower()).get("open"), "%H:%M")
+            slot = (time_obj - opening_time_obj) // -timedelta(minutes=self.config['MIN_ACTIVITY_DURATION']-1) * -1
+            slot = 0 if not slot else slot-1
+            timeslot_list_tmp[i] = f"{day}-{slot}"
+        return ",".join(timeslot_list_tmp)
+        

--- a/pear_schedule/api/medication_schedule_router.py
+++ b/pear_schedule/api/medication_schedule_router.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 import datetime
 import pandas as pd
 from fastapi import APIRouter, Request, HTTPException
@@ -9,6 +10,7 @@ from pear_schedule.db_utils.writer import MedicationScheduleWrite
 from pear_schedule.api.utils import MedicationAlreadyAdministeredException, MedicationScheduleNotFoundException
 
 from pear_schedule.db_utils.views import TodayMedicationScheduleView
+from pear_schedule.scheduler.medicationScheduling import medicationScheduler
 
 logger = logging.getLogger(__name__)
 
@@ -17,11 +19,15 @@ router = APIRouter(tags=["Medication Schedule"])
 @router.get("/get/")
 def get_medication_schedule(request: Request):
     try:
+        medicationSchedules = medicationScheduler.generateTodayMedSchedule()
+        if not MedicationScheduleWrite.write(schedules=medicationSchedules):
+            raise HTTPException(status_code=500, detail="Failed to write medication schedules to the database")
         medication_schedules: pd.DataFrame = TodayMedicationScheduleView.get_data()
         return JSONResponse(status_code=200, content=jsonable_encoder(medication_schedules.to_dict(orient="records")))
     except Exception as e:
         logger.info(str(e))
-        raise HTTPException(status_code=500, detail=f"An error occurred while fetching medication schedules: {str(e)}")
+        logger.info(traceback.format_exc())
+        raise HTTPException(status_code=400, detail=f"An error occurred while fetching medication schedules: {str(e)}")
 
 @router.put("/update/")
 def update_medication_schedule(
@@ -40,8 +46,3 @@ def update_medication_schedule(
         raise HTTPException(status_code=404, detail="Medication schedule to be updated is not found")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"An error has occurred while updating medication schedule: {str(e)}")
-
-# # convenient function to refresh medication schedule data
-# @router.get("/MedicationSchedule/Refresh")
-# def refreshMedicationSchedule(request: Request):
-#     pass

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -425,7 +425,7 @@ class DisrecommendedActivitiesView(BaseView):
 
 class MedicationView(BaseView): # Just medication table view
     @classmethod
-    def build_query(cls) -> Select:
+    def build_query(cls, curDate=False) -> Select:
         logger.info("Building prescription view query")
         schema = DB.schema
         curDateTime = datetime.now()
@@ -438,6 +438,12 @@ class MedicationView(BaseView): # Just medication table view
             # medication.c["EndDateTime"] >= curDateTime
             medication.c["IsDeleted"] == False
         )
+        if curDate:
+            # startDateTime <| curDateTime |> endDateTime
+            query = query.where(
+                medication.c["StartDateTime"] <= curDateTime,
+                medication.c["EndDateTime"] >= curDateTime
+            )
         return query
 #ROUTINETable Not Ready, add in once ready.
 class ValidRoutineActivitiesView(BaseView): # 

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -548,6 +548,13 @@ class ExistingScheduleView(BaseView): # check if have existing schedule
             schedule.c["ScheduleID"],
             schedule.c["PatientID"],
             schedule.c["MedicationSchedule"],
+            schedule.c["Monday"],
+            schedule.c["Tuesday"],
+            schedule.c["Wednesday"],
+            schedule.c["Thursday"],
+            schedule.c["Friday"],
+            schedule.c["Saturday"],
+            schedule.c["Sunday"],
         ).where(schedule.c["IsDeleted"] == False)
 
         # TODO: May need to tighten the condition

--- a/pear_schedule/db_utils/writer.py
+++ b/pear_schedule/db_utils/writer.py
@@ -7,7 +7,7 @@ from typing import Mapping, List, Dict
 
 from sqlalchemy import Connection, column, delete, select, func, literal_column, column
 from pear_schedule.db import DB
-from pear_schedule.db_utils.views import ExistingScheduleView, DeletedMedicationView
+from pear_schedule.db_utils.views import ExistingScheduleView, DeletedMedicationView, WeeklyScheduleView
 from pear_schedule.scheduler.medicationScheduling import medicationScheduleData
 from pear_schedule.utils import ConfigDependant, DBTABLES
 from pear_schedule.models.schedule_model import Schedule
@@ -112,12 +112,21 @@ class ScheduleWriter(ConfigDependant):
                 if not overwriteExisting:
                     # check if have existing schedule, if have then just ignore
                     existingScheduleDF = ExistingScheduleView.get_data(conn=conn, start_dateTime=start_of_week, patient_id=p)
-                    if len(existingScheduleDF) > 0:
-                        continue
-                    
                     schedule_data["CreatedDateTime"] = today ## Mandatory Field 
-                    # Use the add method to add data to the session
-                    schedule_instance = schedule_table.insert().values(schedule_data)
+                    if len(existingScheduleDF) > 0:
+                        null_schedule = False
+                        for day in cls.config["OPEN_DAYS"]:
+                           if not existingScheduleDF.iloc[0][day]:
+                              null_schedule = True
+                              break
+                        if not null_schedule:
+                           continue
+                        schedule_instance = schedule_table.update().values(schedule_data).where(
+                            schedule_table.c["ScheduleID"] == int(existingScheduleDF.iloc[0]["ScheduleID"])
+                        )
+                    else:
+                        # Use the add method to add data to the session
+                        schedule_instance = schedule_table.insert().values(schedule_data)
                 else:
                     if schedule_meta is None:
                         raise Exception("schedule_meta must be provided when overwriteExisting is used for schedules")
@@ -201,7 +210,7 @@ class MedicationScheduleWrite(ConfigDependant):
                   session.rollback()
                   return False # do not proceed if unable to delete
             try:
-              if not schedules:
+              if schedules:
                 return cls.__writeRecordsUsingSchedules(conn, schedules)
               return cls.__writeRecords(conn) # transaction will be automatically committed (begin once)
             except Exception as e:
@@ -308,7 +317,8 @@ class MedicationScheduleWrite(ConfigDependant):
           for med in meds:
             # if schedule id is none, create a new schedule for the patient, primarily so as to allow flushing of records to medlog
             sid = med["ScheduleID"]
-            if not sid:
+            x = ExistingScheduleView.get_data(conn=conn, start_dateTime=start_of_week, patient_id=patient_id)
+            if not sid and x.empty:
                 data = {
                    "PatientID": patient_id,
                    "StartDate": start_of_week,
@@ -321,9 +331,11 @@ class MedicationScheduleWrite(ConfigDependant):
                 }
                 result = conn.execute(schedule_table.insert().values(data))
                 sid = result.inserted_primary_key[0] # returns a row obj representing a NamedTuple
+            else:
+                sid = sid or x.iloc[0]["ScheduleID"]
             with Session(bind=conn) as s:
                 try:
-                  med["ScheduleID"] = sid
+                  med["ScheduleID"] = int(sid)
                   s.merge(MedicationSchedule(**med))
                   s.commit()
                 except Exception as e:
@@ -383,7 +395,7 @@ class MedicationScheduleWrite(ConfigDependant):
         
         medicationLog = pd.concat([expiredSchedules, deletedMedications, alteredMedications])
         if medicationLog.empty: return # if there is nothing that was deleted, then no need to update logs, return
-        medicationLog["AdministerDate"] = medicationLog["AdministerDate"].dt.strftime(cls.config["STD_DATE_FORMAT"])
+        medicationLog["AdministerDate"] = pd.to_datetime(medicationLog["AdministerDate"]).dt.strftime(cls.config["STD_DATE_FORMAT"])
         date_str = medicationLog["AdministerDate"].mode()[0]
         medicationLog = medicationLog.drop("AdministerDate", axis=1).set_index("ScheduleID").groupby(level=0).apply(lambda x: x.to_dict(orient="records")).to_dict()
 

--- a/pear_schedule/db_utils/writer.py
+++ b/pear_schedule/db_utils/writer.py
@@ -183,8 +183,13 @@ class ScheduleWriter(ConfigDependant):
         return responseData
     
 class MedicationScheduleWrite(ConfigDependant):
+    """
+    This function is responsible for writing medication schedules for the day based on the MedicationSchedule generated
+    by medicationScheduler on /generate and /regenerate. Removes any outstanding medication schedule records due to expiry, deletion of course, etc, 
+    before inserting/updating records.
+    """
     @classmethod
-    def write(cls) -> bool:
+    def write(cls, schedules=None) -> bool:
         with DB.get_engine().begin() as conn:
             with Session(bind=conn) as session:
                 try:
@@ -196,6 +201,8 @@ class MedicationScheduleWrite(ConfigDependant):
                   session.rollback()
                   return False # do not proceed if unable to delete
             try:
+              if not schedules:
+                return cls.__writeRecordsUsingSchedules(conn, schedules)
               return cls.__writeRecords(conn) # transaction will be automatically committed (begin once)
             except Exception as e:
               logger.exception(e)
@@ -287,7 +294,48 @@ class MedicationScheduleWrite(ConfigDependant):
                      medication_schedule_table.update().where(*composite_key_filters).values({"AssignedTo": medication_schedule_data["AssignedTo"]})
                   )
         return True
+    
+    @classmethod
+    def __writeRecordsUsingSchedules(cls, conn: Connection, schedules: Mapping[int, List[int]]) -> bool:
+        today = datetime.datetime.now()
+        start_of_week = today - datetime.timedelta(days=today.weekday())  # Monday -> 00:00:00
+        start_of_week = start_of_week.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_of_week = start_of_week + datetime.timedelta(days=6, hours=23, minutes=59, seconds=59, microseconds=0)  # Sunday -> 23:59:59
         
+        schedule_table = DB.schema.tables[cls.config["DB_TABLES"].SCHEDULE_TABLE]
+        for patient_id, meds in schedules.items():
+          if len(meds) == 0: continue
+          for med in meds:
+            # if schedule id is none, create a new schedule for the patient, primarily so as to allow flushing of records to medlog
+            sid = med["ScheduleID"]
+            if not sid:
+                data = {
+                   "PatientID": patient_id,
+                   "StartDate": start_of_week,
+                   "EndDate": end_of_week,
+                   "IsDeleted": 0,
+                   "UpdatedDateTime": today,
+                   "CreatedById": SYSTEM_USER_ID,
+                   "ModifiedById": SYSTEM_USER_ID,
+                   "CreatedDateTime": today
+                }
+                result = conn.execute(schedule_table.insert().values(data))
+                sid = result.inserted_primary_key[0] # returns a row obj representing a NamedTuple
+            with Session(bind=conn) as s:
+                try:
+                  med["ScheduleID"] = sid
+                  s.merge(MedicationSchedule(**med))
+                  s.commit()
+                except Exception as e:
+                  logger.error(f"Error with merge: {e}\n\n{traceback.format_exc()}")
+                  s.rollback()
+                  return False
+                
+        return True
+
+    """
+    This function flushes outstanding medication schedule records to the medication log field in Schedule based on the schedule id.
+    """
     @classmethod
     def __checkAndFlush(cls, conn: Connection, session: Session):
         existingMedicationSchedule: pd.DataFrame = pd.read_sql(select(MedicationSchedule), session.bind)

--- a/pear_schedule/scheduler/medicationScheduling.py
+++ b/pear_schedule/scheduler/medicationScheduling.py
@@ -3,7 +3,7 @@ import datetime
 import pandas as pd
 from typing import List, Mapping, Dict
 from pear_schedule.scheduler.baseScheduler import BaseScheduler
-from pear_schedule.db_utils.views import MedicationView, CaregiverAllocatedView
+from pear_schedule.db_utils.views import MedicationView, CaregiverAllocatedView, ExistingScheduleView
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +51,8 @@ class medicationScheduleData:
             # ======== Inserting medication into the scheduler ========
             slots = administerTime.split(",")
             allocation_row: pd.DataFrame = allocationDF[allocationDF['patientId'] == pid]
-            assigned_caregiver: str = (allocation_row.iloc[0]['caregiverId'].strip() or allocation_row.iloc[0]['tempCaregiverId']) if not allocation_row.empty else "UNASSIGNED"
+            assigned_caregiver: str = (allocation_row.iloc[0]['caregiverId'].strip() or allocation_row.iloc[0]['tempCaregiverId'] or allocation_row.iloc[0]['supervisorId']) if not allocation_row.empty \
+                else "UNASSIGNED"
             
             for slot in slots:
                 # full_hour = cls.config["DAY_TIMESLOTS"][hour]
@@ -137,6 +138,51 @@ class medicationScheduler(BaseScheduler):
               patientSchedules[pid][day][hour] += s
         
         return medicationSchedule_ref
+    
+    """
+    This function is an alternative, meant to be called by the /MedicationSchedule/get/ endpoint to retrieve the medication schedules
+    only for the day for convenience (without having to call /generate or /regenerate to get the latest schedules)
+    """
+    @classmethod
+    def generateTodayMedSchedule(cls) -> Mapping[int, List[Dict]]:
+        # startDateTime to endDateTime range contains today
+        medicationDF = MedicationView.get_data(curDate=True)
+        allocationDF = CaregiverAllocatedView.get_data()
+        today = datetime.datetime.now()
+
+        # note that there may be multiple medications for the same patient
+        medicationSchedules = {}
+        for row in medicationDF.itertuples():
+            pid = row.PatientID
+            mid = row.MedicationID
+            sid = None
+            administerTimes = row.AdministerTime
+
+            # if there is already a schedule generated for the week, use that schedule id
+            existingSchedule = ExistingScheduleView.get_data(patient_id=pid, start_dateTime=today)
+            if not existingSchedule.empty:
+                sid = existingSchedule.iloc[0]['ScheduleID']
+
+            allocation_row: pd.DataFrame = allocationDF[allocationDF['patientId'] == pid]
+            assigned_caregiver: str = (allocation_row.iloc[0]['caregiverId'].strip() or allocation_row.iloc[0]['tempCaregiverId'] or allocation_row.iloc[0]['supervisorId']) if not allocation_row.empty \
+                else "UNASSIGNED"
+            administerTimes: list = administerTimes.split(",")
+            for time in administerTimes:
+                qualified_day = today.strftime("%A")
+                if qualified_day not in cls.config["OPEN_DAYS"]:
+                    continue
+                slot = getTimeSlot(cls, qualified_day, time)
+                if slot <= -1 or slot >= cls.config["SLOTS_PER_DAY"].get(qualified_day):
+                    continue
+                medicationSchedules.setdefault(pid, []).append({
+                    "MedicationID": mid,
+                    "AdministerTime": time,
+                    "AdministerDate": today.strftime(cls.config["STD_DATE_FORMAT"]),
+                    "AssignedTo": assigned_caregiver,
+                    "ScheduleID": sid
+                })
+            
+        return medicationSchedules
 
 
 def getTimeSlot(cls, day, time):


### PR DESCRIPTION
This PR includes the following:
1. Refactoring of /MedicationSchedule/get endpoint to not have to manually refresh schedules in order to retrieve the latest medication schedules
2. Adding of translation from fixed_time_slots, now expected to be in the form "Monday 09:00,Tuesday 15:00" (starting times) to scheduler-required fixed time slots, i.e. "0-0,1-8)