### PR TITLE
Fix week-boundary bugs and add past-day/medication overwrite protection

### DIFF
--- a/.github/workflows/base-cd.yaml
+++ b/.github/workflows/base-cd.yaml
@@ -1,0 +1,163 @@
+name: Base CD
+
+# Reusable deployment workflow shared by every environment.
+#
+# Config is NOT passed in by the caller. A job that calls a reusable workflow
+# cannot declare `environment:`, so any vars/secrets referenced in the caller
+# would resolve against repository scope (prod values) instead of the
+# environment. The jobs below DO declare `environment:`, so `vars.*` and
+# `secrets.*` here resolve correctly against the GitHub Environment named by
+# the `environment` input.
+#
+# The caller supplies only structural inputs: which namespace, which object
+# names, which files. Both environments of this service share one cluster,
+# so those MUST be parameterised - nothing about staging or prod is hardcoded.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'GitHub Environment to read vars/secrets from (must match the name in GitHub exactly)'
+        required: true
+        type: string
+      runner-label:
+        description: 'JSON array of self-hosted runner labels'
+        required: true
+        type: string
+      namespace:
+        description: 'Kubernetes namespace to deploy into'
+        required: true
+        type: string
+      deployment-name:
+        description: 'Name of the Deployment object'
+        required: true
+        type: string
+      container-name:
+        description: 'Container name inside the pod (used by kubectl set image)'
+        required: true
+        type: string
+      configmap-name:
+        description: 'ConfigMap the Deployment reads via envFrom'
+        required: true
+        type: string
+      docker-image-name:
+        description: 'Image name to build and push'
+        required: true
+        type: string
+      kube-deployment-file:
+        required: true
+        type: string
+      kube-cronjob-file:
+        required: true
+        type: string
+      dockerfile:
+        required: false
+        type: string
+        default: 'Dockerfile.dev'
+
+permissions:
+  contents: read
+
+jobs:
+  precheck:
+    runs-on: ${{ fromJSON(inputs.runner-label) }}
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Check kubectl permissions
+        run: |
+          kubectl auth can-i create deployments -n ${{ inputs.namespace }} \
+            || (echo "No permission to create deployments in ${{ inputs.namespace }}" && exit 1)
+          kubectl auth can-i patch deployments -n ${{ inputs.namespace }} \
+            || (echo "No permission to patch deployments in ${{ inputs.namespace }}" && exit 1)
+
+      - name: Check Docker registry access
+        run: docker info || (echo "Docker not accessible" && exit 1)
+
+  deploy:
+    needs: precheck
+    runs-on: ${{ fromJSON(inputs.runner-label) }}
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set commit SHA
+        run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      # vars.*    = GitHub Environment variables (non-sensitive config)
+      # secrets.* = GitHub Environment secrets (passwords only)
+      - name: Create .env from environment variables and secrets
+        run: |
+          echo "DB_DRIVER_DEV=${{ vars.DB_DRIVER_DEV }}" >> .env
+          echo "DB_SERVER_DEV=${{ vars.DB_SERVER_DEV }}" >> .env
+          echo "DB_DATABASE_DEV=${{ vars.DB_DATABASE_DEV }}" >> .env
+          echo "DB_DATABASE_PORT=${{ vars.DB_DATABASE_PORT }}" >> .env
+          echo "DB_USERNAME_DEV=${{ vars.DB_USERNAME_DEV }}" >> .env
+          echo "DB_PASSWORD_DEV=${{ secrets.DB_PASSWORD_DEV }}" >> .env
+          echo "RABBITMQ_HOST=${{ vars.RABBITMQ_HOST }}" >> .env
+          echo "RABBITMQ_PORT=${{ vars.RABBITMQ_PORT }}" >> .env
+          echo "RABBITMQ_USER=${{ vars.RABBITMQ_USER }}" >> .env
+          echo "RABBITMQ_PASS=${{ secrets.RABBITMQ_PASS }}" >> .env
+          echo "RABBITMQ_VIRTUAL_HOST=${{ vars.RABBITMQ_VIRTUAL_HOST }}" >> .env
+          echo "WEB_FE_ORIGIN=${{ vars.WEB_FE_ORIGIN }}" >> .env
+          echo "WEB_FE_ORIGIN_STAGING=${{ vars.WEB_FE_ORIGIN_STAGING }}" >> .env
+          echo "USER_BE_ORIGIN=${{ vars.USER_BE_ORIGIN }}" >> .env
+          echo "ENVIRONMENT=${{ inputs.environment }}" >> .env
+
+      # A var or secret missing from the environment resolves to an empty string
+      # rather than erroring, which would silently misconfigure the pod.
+      - name: Verify nothing resolved to empty
+        run: |
+          MISSING=$(grep -E '=$' .env | cut -d= -f1 || true)
+          if [ -n "$MISSING" ]; then
+            echo "Empty or missing in the '${{ inputs.environment }}' GitHub Environment:"
+            echo "$MISSING"
+            echo "Add them under Settings > Environments > ${{ inputs.environment }}"
+            exit 1
+          fi
+          echo "All environment variables and secrets present."
+
+      - name: Create/Update ConfigMap in Kubernetes
+        run: |
+          kubectl create configmap ${{ inputs.configmap-name }} \
+            -n ${{ inputs.namespace }} \
+            --from-env-file=.env \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Build Docker image
+        run: |
+          docker build --no-cache -f ${{ inputs.dockerfile }} \
+            -t ${{ inputs.docker-image-name }}:${{ env.COMMIT_SHA }} .
+
+      - name: Tag and push to local registry
+        run: |
+          docker tag ${{ inputs.docker-image-name }}:${{ env.COMMIT_SHA }} \
+                     localhost:5000/${{ inputs.docker-image-name }}:${{ env.COMMIT_SHA }}
+          docker push localhost:5000/${{ inputs.docker-image-name }}:${{ env.COMMIT_SHA }}
+
+      # Git stays the source of truth for the whole spec (Service, ports, labels).
+      - name: Apply Kubernetes manifests
+        run: kubectl apply -f '${{ inputs.kube-deployment-file }}'
+
+      # Pin the running image to this exact commit so the deployed version is traceable.
+      - name: Roll out this commit's image
+        run: |
+          kubectl set image deployment/${{ inputs.deployment-name }} \
+            -n ${{ inputs.namespace }} \
+            ${{ inputs.container-name }}=host.minikube.internal:5000/${{ inputs.docker-image-name }}:${{ env.COMMIT_SHA }}
+          kubectl rollout status deployment/${{ inputs.deployment-name }} \
+            -n ${{ inputs.namespace }} --timeout=300s
+
+      - name: Deploy CronJobs
+        run: kubectl apply -f '${{ inputs.kube-cronjob-file }}' -n ${{ inputs.namespace }}
+
+      - name: Verify CronJob targets this namespace
+        run: |
+          kubectl get cronjob -n ${{ inputs.namespace }} -o yaml \
+            | grep -q "http://scheduler-service:8080" \
+            || (echo "CronJob is not using the namespace-local service name" && exit 1)
+
+      - name: Docker maintenance cleanup
+        run: |
+          docker container prune -f
+          docker image prune -f

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -1,4 +1,4 @@
-name: CD
+name: CD-Prod
 
 on:
   push:
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   precheck:
+    if: github.ref == 'refs/heads/scheduler_prod'
     runs-on: [self-hosted, Linux, X64, scheduler]
     steps:
       - name: Check kubectl permissions
@@ -22,6 +23,7 @@ jobs:
           docker info || (echo "Docker not accessible" && exit 1)
 
   deploy:
+    if: github.ref == 'refs/heads/scheduler_prod'
     needs: precheck
     runs-on: [self-hosted, Linux, X64, scheduler]
 

--- a/.github/workflows/cd-stg.yml
+++ b/.github/workflows/cd-stg.yml
@@ -1,0 +1,25 @@
+name: CD (Staging)
+
+on:
+  push:
+    branches: ['scheduler_staging']
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-staging:
+    uses: ./.github/workflows/base-cd.yaml
+    secrets: inherit
+    with:
+      # must match the GitHub Environment name exactly (case-sensitive)
+      environment: 'staging'
+      runner-label: '["self-hosted","Linux","X64","scheduler_staging"]'
+      namespace: 'staging'
+      deployment-name: 'scheduler-service-stg'
+      container-name: 'scheduler-service'
+      configmap-name: 'scheduler-service-stg-env'
+      docker-image-name: 'scheduler_service_stg'
+      kube-deployment-file: './k8s/scheduler_deployment_staging.yaml'
+      kube-cronjob-file: './k8s/scheduler_cronjob.yaml'
+      dockerfile: 'Dockerfile.dev'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["scheduler_prod", "scheduler_staging"]
+  push:
+    branches: ["scheduler_prod", "scheduler_staging"]
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # pyodbc links against unixODBC at runtime, so it needs this to import.
+      - name: Install unixODBC
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y unixodbc-dev gcc
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      # logger/config.py is gitignored and never committed.
+      # Any module that logs fails to import without it.
+      - name: Create logger config
+        run: |
+          mkdir -p pear_schedule/logger
+          cat > pear_schedule/logger/config.py <<'EOF'
+          import logging
+          logger = logging.getLogger("pear_schedule")
+          EOF
+
+      # database.py builds the engine at import time.
+      # engine creation is lazy and tests never connect,
+      # use db_session_mock instead.
+      - name: Run unit tests
+        env:
+          DB_USERNAME_DEV: ci
+          DB_PASSWORD_DEV: ci
+          DB_SERVER_DEV: localhost
+          DB_DATABASE_DEV: ci
+          DB_DATABASE_PORT: "1433"
+          DB_DRIVER_DEV: "ODBC Driver 17 for SQL Server"
+        run: python -m pytest tests/unit_tests -q

--- a/k8s/scheduler_cronjob.yaml
+++ b/k8s/scheduler_cronjob.yaml
@@ -7,20 +7,31 @@ spec:
   # Every Monday at 00:00
   schedule: "0 0 * * 1"
   timeZone: "Asia/Singapore"
+  # don't start a new run if the previous one is still going
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      # after job completion, keep for 5 minutes, then cleanup to prevent accumulation of old job records
       ttlSecondsAfterFinished: 300
+      backoffLimit: 3
       template:
         spec:
+          # create a container based on curl image to make a HTTP GET request
           containers:
           - name: curl-job
             image: curlimages/curl:8.9.0
+            env:
+              # injected by Kubernetes - proves which environment the job ran in
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
             args:
               - /bin/sh
               - -c
               - |
-                echo "Triggering scheduler-service-dev /schedule/generate/..."
-                curl -X GET http://scheduler-service-dev.default.svc.cluster.local:8080/schedule/generate/ || exit 1
+                echo "Triggering /schedule/generate/ in namespace ${POD_NAMESPACE}"
+                curl -fsS -X GET http://scheduler-service:8080/schedule/generate/ || exit 1
           restartPolicy: OnFailure
 ---
 apiVersion: batch/v1
@@ -31,20 +42,25 @@ spec:
   # Everyday, except Mondays, at 00:00
   schedule: "0 0 * * 0,2-6"
   timeZone: "Asia/Singapore"
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      # after job completion, keep for 5 minutes, then cleanup to prevent accumulation of old job records
       ttlSecondsAfterFinished: 300
+      backoffLimit: 3
       template:
         spec:
-          # create a container based on curl image to make a HTTP GET request
           containers:
           - name: curl-job
             image: curlimages/curl:8.9.0
+            env:
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
             args:
               - /bin/sh
               - -c
               - |
-                echo "Triggering scheduler-service-dev /schedule/regenerate/..."
-                curl -X GET http://scheduler-service-dev.default.svc.cluster.local:8080/schedule/regenerate/ || exit 1
+                echo "Triggering /schedule/regenerate/ in namespace ${POD_NAMESPACE}"
+                curl -fsS -X GET http://scheduler-service:8080/schedule/regenerate/ || exit 1
           restartPolicy: OnFailure

--- a/k8s/scheduler_deployment_dev.yaml
+++ b/k8s/scheduler_deployment_dev.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scheduler-service-dev
+  namespace: default
 spec:
   replicas: 1
   selector:
@@ -28,7 +29,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: scheduler-service-dev
+  name: scheduler-service
+  namespace: default
 spec:
   selector:
     app: scheduler-service-dev

--- a/k8s/scheduler_deployment_staging.yaml
+++ b/k8s/scheduler_deployment_staging.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: scheduler-service-stg
+  namespace: staging
+  labels:
+    app: scheduler-service-stg
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scheduler-service-stg
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: scheduler-service-stg
+    spec:
+      containers:
+        - name: scheduler-service
+          image: host.minikube.internal:5000/scheduler_service_stg:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: scheduler-service-stg-env
+          env:
+            - name: TZ
+              value: "Asia/Singapore"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: scheduler-service
+  namespace: staging
+spec:
+  selector:
+    app: scheduler-service-stg
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      nodePort: 30090
+  type: NodePort

--- a/pear_schedule/db_utils/utils.py
+++ b/pear_schedule/db_utils/utils.py
@@ -6,20 +6,17 @@ def compile_query(query: Select) -> str:
     # literal binds might cause errors if datetime is ever used
     return query.compile(compile_kwargs={"literal_binds": True})
 
-def get_monday():
-    today=datetime.now()
+def get_week_start():
+    today = datetime.now()
     monday = (today - timedelta(days=today.weekday())).strftime("%Y-%m-%d")
     return monday
 
-def get_next_sunday():
+def get_week_end():
     today = datetime.now()
-    if today.weekday() == 6:  # If today is Sunday
-        days_until_sunday = 7  # Add 7 days to get the date of the following Sunday
-    else:
-        days_until_sunday = (6 - today.weekday()) % 7  # Calculate the number of days until Sunday
-    next_sunday = today + timedelta(days=days_until_sunday)  # Add days to today's date to get the next Sunday
-    next_sunday = next_sunday.replace(hour=23, minute=59, second = 59)
-    return next_sunday
+    days_until_sunday = 6 - today.weekday()
+    sunday = today + timedelta(days=days_until_sunday)
+    sunday = sunday.replace(hour=23, minute=59, second=59)
+    return sunday
 
 def timeslot_index(offset: timedelta, duration_minutes: int) -> int:
     """Floor-divide a clock-time offset by a slot duration to get a 0-based slot index.

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from sqlalchemy import Connection, Select, and_, func, select
 from pear_schedule.db import DB
-from pear_schedule.db_utils.utils import compile_query, get_next_sunday, get_monday
+from pear_schedule.db_utils.utils import compile_query, get_week_end, get_week_start
 from pear_schedule.utils import ConfigDependant, DBTABLES
 from sqlalchemy import literal_column
 import logging
@@ -73,7 +73,7 @@ class AllActivitiesView(BaseView):
             centre_activity, activity.c["ActivityID"] == centre_activity.c["ActivityID"]
         ).where(
             #centre_activity.c["IsDeleted"] == False,
-            #centre_activity.c["StartDate"] < get_monday(),
+            #centre_activity.c["StartDate"] < get_week_start(),
         )
 
         return query
@@ -103,8 +103,8 @@ class ActivitiesView(BaseView):
         ).where(
             centre_activity.c["IsGroup"] == False,
             centre_activity.c["IsDeleted"] == False,
-            centre_activity.c["StartDate"] <= get_next_sunday(),
-            centre_activity.c["EndDate"] >= get_monday(),
+            centre_activity.c["StartDate"] <= get_week_end(),
+            centre_activity.c["EndDate"] >= get_week_start(),
             centre_activity.c["IsCompulsory"] == False
         )
 
@@ -134,7 +134,7 @@ class PatientsView(BaseView):
             centre_activity_preference.c["IsLike"] > 0,
             centre_activity_preference.c["IsDeleted"] == False,
             centre_activity.c["IsDeleted"] == False,
-            centre_activity.c["StartDate"] <= get_next_sunday(),
+            centre_activity.c["StartDate"] <= get_week_end(),
         ).cte()
 
         query: Select = select(
@@ -175,7 +175,7 @@ class PatientsUnpreferredView(BaseView):
             centre_activity_preference.c["IsLike"] == 0,
             centre_activity_preference.c["IsDeleted"] == False,
             centre_activity.c["IsDeleted"] == False,
-            centre_activity.c["StartDate"] <= get_next_sunday(),
+            centre_activity.c["StartDate"] <= get_week_end(),
         ).cte()
 
         query: Select = select(
@@ -230,8 +230,8 @@ class GroupActivitiesOnlyView(BaseView): # Just group activities only
         ).where(centre_activity.c["IsCompulsory"] == False
         ).where(centre_activity.c["IsDeleted"] == False
         ).where(
-        centre_activity.c["EndDate"] >= get_monday(),
-        ).where(centre_activity.c["StartDate"] <= get_next_sunday(),
+        centre_activity.c["EndDate"] >= get_week_start(),
+        ).where(centre_activity.c["StartDate"] <= get_week_end(),
         ) #EndDate has been moved from ActivityTable to CentreActivity Table
 
         return query
@@ -259,8 +259,8 @@ class GroupActivitiesPreferenceView(BaseView): # Just group activities preferenc
             centre_activity_preference.c["IsDeleted"] == False,
             centre_activity.c["IsDeleted"] == False,
         ).where(
-            centre_activity.c["StartDate"] <= get_next_sunday(),
-            centre_activity.c["EndDate"] >= get_monday(),
+            centre_activity.c["StartDate"] <= get_week_end(),
+            centre_activity.c["EndDate"] >= get_week_start(),
         )
 
 
@@ -289,8 +289,8 @@ class GroupActivitiesRecommendationView(BaseView): # Just group activities prefe
             centre_activity_recommendation.c["IsDeleted"] == False,
             centre_activity.c["IsDeleted"] == False,
         ).where(
-            centre_activity.c["StartDate"] <= get_next_sunday(),
-            centre_activity.c["EndDate"] >= get_monday(),
+            centre_activity.c["StartDate"] <= get_week_end(),
+            centre_activity.c["EndDate"] >= get_week_start(),
         )
 
 
@@ -349,8 +349,8 @@ class CompulsoryActivitiesOnlyView(BaseView): # Just compulsory activities only
             centre_activity.c["IsCompulsory"] == True,
             centre_activity.c["IsDeleted"] == False,
             centre_activity.c["IsFixed"] == True,
-            centre_activity.c["EndDate"] >= get_monday(),
-            centre_activity.c["StartDate"] <= get_next_sunday(),
+            centre_activity.c["EndDate"] >= get_week_start(),
+            centre_activity.c["StartDate"] <= get_week_end(),
         ) #EndDate has been moved from ActivityTable to CentreActivity Table
 
         return query
@@ -382,8 +382,8 @@ class RecommendedActivitiesView(BaseView):
             recommendations.c["IsDeleted"] == False,
             recommendations.c["DoctorRecommendation"] > 0,
             centre_activity.c["IsGroup"] == False,
-            centre_activity.c["StartDate"] <= get_next_sunday(),
-            centre_activity.c["EndDate"] >= get_monday(),
+            centre_activity.c["StartDate"] <= get_week_end(),
+            centre_activity.c["EndDate"] >= get_week_start(),
             centre_activity.c["IsCompulsory"] == False
         )
 

--- a/pear_schedule/db_utils/views.py
+++ b/pear_schedule/db_utils/views.py
@@ -308,14 +308,9 @@ class GroupActivitiesExclusionView(BaseView): # Just group activities preference
 
 
         today = datetime.now()
-        if today.weekday() == 6: #sunday and generate for next week
-            start_of_week = today + timedelta(days=1, hours=0, minutes=0, seconds=0, microseconds=0)
-            start_of_week = start_of_week.replace(hour=0, minute=0, second=0, microsecond=0)
-            end_of_week = start_of_week + timedelta(days=6, hours=23, minutes=59, seconds=59, microseconds=0)
-        else: # other weekday and generate for current week
-            start_of_week = today - timedelta(days=today.weekday(), hours=0, minutes=0, seconds=0, microseconds=0)  # Monday -> 00:00:00
-            start_of_week = start_of_week.replace(hour=0, minute=0, second=0, microsecond=0)
-            end_of_week = start_of_week + timedelta(days=6, hours=23, minutes=59, seconds=59, microseconds=0)  # Sunday -> 23:59:59
+        start_of_week = today - timedelta(days=today.weekday(), hours=0, minutes=0, seconds=0, microseconds=0)  # Monday -> 00:00:00
+        start_of_week = start_of_week.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_of_week = start_of_week + timedelta(days=6, hours=23, minutes=59, seconds=59, microseconds=0)  # Sunday -> 23:59:59
 
         query: Select = select(
             centre_activity.c["CentreActivityID"],

--- a/pear_schedule/db_utils/writer.py
+++ b/pear_schedule/db_utils/writer.py
@@ -34,6 +34,31 @@ def _past_day_columns(start_of_week: datetime.datetime, today: datetime.datetime
         if (start_of_week.date() + datetime.timedelta(days=i)) < today.date()
     }
 
+
+def _past_medication_dates(start_of_week: datetime.datetime, today: datetime.datetime, date_format: str) -> set:
+    """Medication dates already in the past, shouldn't be overwritten."""
+    return {
+        (start_of_week.date() + datetime.timedelta(days=i)).strftime(date_format)
+        for i in range(7)
+        if (start_of_week.date() + datetime.timedelta(days=i)) < today.date()
+    }
+
+
+def _merge_medication_schedule(existing_json: str, new_data: Dict, past_dates: set) -> str:
+    """Keeps past dates from existing_json, uses new_data for the rest."""
+    try:
+        existing = json.loads(existing_json) if existing_json else {}
+    except (TypeError, ValueError):
+        existing = {}
+
+    merged = dict(new_data)
+    for date_str in past_dates:
+        if date_str in existing:
+            merged[date_str] = existing[date_str]
+        else:
+            merged.pop(date_str, None)
+    return json.dumps(merged)
+
 class ScheduleWriter(ConfigDependant):
     @classmethod
     def write(
@@ -67,6 +92,7 @@ class ScheduleWriter(ConfigDependant):
         start_of_week = start_of_week.replace(hour=0, minute=0, second=0, microsecond=0)
         end_of_week = start_of_week + datetime.timedelta(days=6, hours=23, minutes=59, seconds=59, microseconds=0)  # Sunday -> 23:59:59
         past_days = _past_day_columns(start_of_week, today)
+        past_medication_dates = _past_medication_dates(start_of_week, today, cls.config["STD_DATE_FORMAT"])
 
         medication_schedule: Mapping[int, Dict[datetime.date, List[Dict]]] = medicationScheduleRef.reformatMedicationScheduleData(cls)
 
@@ -86,7 +112,15 @@ class ScheduleWriter(ConfigDependant):
                         key = day_labels[j]
                         activities[key] = 'Free and Easy' if not activity else activity
                     converted_schedule[day] = json.dumps(activities)
-                
+
+                existingScheduleDF = ExistingScheduleView.get_data(conn=conn, start_dateTime=start_of_week, patient_id=p)
+                existing_medication_schedule = (
+                    existingScheduleDF.iloc[0]["MedicationSchedule"] if len(existingScheduleDF) > 0 else None
+                )
+                medication_schedule_json = _merge_medication_schedule(
+                    existing_medication_schedule, medication_schedule.get(int(p), {}), past_medication_dates
+                )
+
                 schedule_data = {
                     ## "ScheduleID": _ (not necessary as it is a primary key which will automatically be created)
                     "PatientID": p,
@@ -99,18 +133,17 @@ class ScheduleWriter(ConfigDependant):
                     "Friday": converted_schedule.get("Friday", ""),
                     "Saturday": converted_schedule.get("Saturday", ""),
                     "Sunday": converted_schedule.get("Sunday", ""),
-                    "MedicationSchedule": json.dumps(medication_schedule.get(int(p), {})),
+                    "MedicationSchedule": medication_schedule_json,
                     # "MedicationLog": "",
-                    "IsDeleted": 0, ## Mandatory Field 
-                    "UpdatedDateTime": today, ## Mandatory Field 
+                    "IsDeleted": 0, ## Mandatory Field
+                    "UpdatedDateTime": today, ## Mandatory Field
                     "CreatedById": SYSTEM_USER_ID,
                     "ModifiedById": SYSTEM_USER_ID
                 }
 
                 if not overwriteExisting:
                     # check if have existing schedule, if have then just ignore
-                    existingScheduleDF = ExistingScheduleView.get_data(conn=conn, start_dateTime=start_of_week, patient_id=p)
-                    schedule_data["CreatedDateTime"] = today ## Mandatory Field 
+                    schedule_data["CreatedDateTime"] = today ## Mandatory Field
                     if len(existingScheduleDF) > 0:
                         null_schedule = False
                         for day in cls.config["OPEN_DAYS"]:

--- a/pear_schedule/db_utils/writer.py
+++ b/pear_schedule/db_utils/writer.py
@@ -24,6 +24,16 @@ logger = logging.getLogger(__name__)
 # TODO: REPLACE THIS FOR AUDIT / LOGGING
 SYSTEM_USER_ID = "SYSTEM"
 
+WEEKDAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+
+
+def _past_day_columns(start_of_week: datetime.datetime, today: datetime.datetime) -> set:
+    """Day columns already in the past, shouldn't be overwritten."""
+    return {
+        day for i, day in enumerate(WEEKDAYS)
+        if (start_of_week.date() + datetime.timedelta(days=i)) < today.date()
+    }
+
 class ScheduleWriter(ConfigDependant):
     @classmethod
     def write(
@@ -56,6 +66,7 @@ class ScheduleWriter(ConfigDependant):
         start_of_week = today - datetime.timedelta(days=today.weekday())  # Monday -> 00:00:00
         start_of_week = start_of_week.replace(hour=0, minute=0, second=0, microsecond=0)
         end_of_week = start_of_week + datetime.timedelta(days=6, hours=23, minutes=59, seconds=59, microseconds=0)  # Sunday -> 23:59:59
+        past_days = _past_day_columns(start_of_week, today)
 
         medication_schedule: Mapping[int, Dict[datetime.date, List[Dict]]] = medicationScheduleRef.reformatMedicationScheduleData(cls)
 
@@ -108,7 +119,8 @@ class ScheduleWriter(ConfigDependant):
                               break
                         if not null_schedule:
                            continue
-                        schedule_instance = schedule_table.update().values(schedule_data).where(
+                        update_data = {k: v for k, v in schedule_data.items() if k not in past_days}
+                        schedule_instance = schedule_table.update().values(update_data).where(
                             schedule_table.c["ScheduleID"] == int(existingScheduleDF.iloc[0]["ScheduleID"])
                         )
                     else:
@@ -129,7 +141,8 @@ class ScheduleWriter(ConfigDependant):
 
                         schedule_data.update(schedule_meta[p])
                         schedule_data.pop("ScheduleID")
-                        schedule_instance = schedule_table.update().values(schedule_data).where(
+                        update_data = {k: v for k, v in schedule_data.items() if k not in past_days}
+                        schedule_instance = schedule_table.update().values(update_data).where(
                             schedule_table.c["ScheduleID"] == schedule_meta[p]["ScheduleID"]
                         )
                 conn.execute(schedule_instance)

--- a/pear_schedule/scheduler/individualScheduling.py
+++ b/pear_schedule/scheduler/individualScheduling.py
@@ -97,8 +97,7 @@ class RecommendedRoutineActivityScheduler(IndividualActivityScheduler):
     @classmethod
     def fillSchedule(cls, schedules: Mapping[str, List[str]], week_start: datetime.datetime = None) -> None:
         week_start = week_start or datetime.datetime.now() - datetime.timedelta(days = datetime.datetime.now().weekday())
-        today = datetime.datetime.now()
-        week_end = today - datetime.timedelta(days=today.weekday()) + datetime.timedelta(days=6)
+        week_end = week_start + datetime.timedelta(days=6)
         week_end = week_end.replace(hour=23, minute=59, second=59)
 
         with DB.get_engine().begin() as conn:
@@ -115,7 +114,8 @@ class RecommendedRoutineActivityScheduler(IndividualActivityScheduler):
             recommendations["ActivityEndDate"] = recommendations["ActivityEndDate"].apply(pd.Timestamp)
  
             # filter out activities that are not available this week, i.e. only consider activities that run past week_end
-            # recommendations = recommendations[(recommendations["ActivityEndDate"] > week_end)] #| (recommendations["ActivityEndDate"].isna())]
+            # null ActivityEndDate means indefinite (never expires), so it always passes
+            recommendations = recommendations[recommendations["ActivityEndDate"].isna() | (recommendations["ActivityEndDate"] > week_end)]
 
             # add an extra row at end for easier handling of final patient
             dummy_row = recommendations.iloc[0:1].copy(deep=True)

--- a/tests/unit_tests/test_db_utils_utils.py
+++ b/tests/unit_tests/test_db_utils_utils.py
@@ -1,6 +1,33 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
+from pear_schedule.db_utils import utils
 from pear_schedule.db_utils.utils import day_timeslot_label, day_timeslot_labels, timeslot_index
+
+
+class TestGetWeekStartAndGetWeekEnd:
+    """get_week_end() used to skip to next Sunday on Sundays instead of today."""
+
+    def _freeze(self, monkeypatch, fixed_now: datetime):
+        class FixedDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return fixed_now
+
+        monkeypatch.setattr(utils, "datetime", FixedDatetime)
+
+    def test_sunday_uses_current_week_sunday_not_next_week(self, monkeypatch):
+        # Sunday 2024-03-24 is the last day of the week starting Monday 2024-03-18.
+        self._freeze(monkeypatch, datetime(2024, 3, 24, 10, 0, 0))
+
+        assert utils.get_week_start() == "2024-03-18"
+        assert utils.get_week_end() == datetime(2024, 3, 24, 23, 59, 59)
+
+    def test_midweek_day_still_returns_current_week_sunday(self, monkeypatch):
+        # Wednesday 2024-03-20, same week as above.
+        self._freeze(monkeypatch, datetime(2024, 3, 20, 10, 0, 0))
+
+        assert utils.get_week_start() == "2024-03-18"
+        assert utils.get_week_end() == datetime(2024, 3, 24, 23, 59, 59)
 
 
 class TestTimeslotIndex:

--- a/tests/unit_tests/test_individual_schedule.py
+++ b/tests/unit_tests/test_individual_schedule.py
@@ -221,9 +221,8 @@ class TestRecommendedRoutineFillSchedule:
 
         assert schedules[1][0][1] == "Physiotherapy"
 
-    def test_expired_activity_end_date_is_still_scheduled(self, monkeypatch):
-        """(BUG) the expiry filter is commented out, so this still gets scheduled even
-        though ActivityEndDate is in the past."""
+    def test_expired_activity_end_date_is_not_scheduled(self, monkeypatch):
+        """An explicit ActivityEndDate in the past should exclude the activity."""
         from pear_schedule.scheduler.individualScheduling import RecommendedRoutineActivityScheduler
 
         monkeypatch.setattr(RecommendedRoutineActivityScheduler, "config", self._config(), raising=False)
@@ -239,7 +238,26 @@ class TestRecommendedRoutineFillSchedule:
         with _patch_recommended_stage(recommendations_df, patients_df=patients_df):
             RecommendedRoutineActivityScheduler.fillSchedule(schedules, week_start=week_start)
 
-        assert schedules[1][0][1] == "Expired Activity"
+        assert schedules[1][0][1] == ""
+
+    def test_null_activity_end_date_is_indefinite_and_still_scheduled(self, monkeypatch):
+        """A null ActivityEndDate means the activity never expires."""
+        from pear_schedule.scheduler.individualScheduling import RecommendedRoutineActivityScheduler
+
+        monkeypatch.setattr(RecommendedRoutineActivityScheduler, "config", self._config(), raising=False)
+        recommendations_df = pd.DataFrame({
+            "ActivityID": [1], "IsFixed": [1], "MinDuration": [30],
+            "ActivityTitle": ["Indefinite Activity"], "FixedTimeSlots": ["0-1"],
+            "PatientID": [1], "ActivityEndDate": [pd.NaT],
+        })
+        patients_df = pd.DataFrame({"PatientID": [1], "PreferredActivityID": [999], "ActivityEndDate": [pd.Timestamp("2099-12-31")]})
+        schedules = {1: [["", "", "", ""]]}
+        week_start = datetime.datetime(2024, 3, 18)
+
+        with _patch_recommended_stage(recommendations_df, patients_df=patients_df):
+            RecommendedRoutineActivityScheduler.fillSchedule(schedules, week_start=week_start)
+
+        assert schedules[1][0][1] == "Indefinite Activity"
 
     def test_all_flexible_recommended_activities_are_scheduled(self, monkeypatch):
         """No fixed activities means no time-slot sets to union; __fillByFixedTimeSlots

--- a/tests/unit_tests/test_views.py
+++ b/tests/unit_tests/test_views.py
@@ -6,12 +6,13 @@ Just build_query() / compile_query() here, no live DB.
 from datetime import date, datetime
 
 import pytest
-from sqlalchemy import MetaData, Table, Column, Integer, String, Boolean, Date, create_engine, insert
+from sqlalchemy import MetaData, Table, Column, Integer, String, Boolean, Date, DateTime, create_engine, insert
 
 from pear_schedule.db_utils import views
 from pear_schedule.db_utils.views import (
     ActivitiesView,
     CompulsoryActivitiesOnlyView,
+    GroupActivitiesExclusionView,
     GroupActivitiesOnlyView,
     GroupActivitiesPreferenceView,
     GroupActivitiesRecommendationView,
@@ -83,6 +84,15 @@ def _make_fake_schema() -> MetaData:
         Column("DoctorRecommendation", Integer),
         Column("IsDeleted", Boolean),
     )
+    Table(
+        "REF_ACTIVITY_EXCLUSION", schema,
+        Column("ActivityExclusionID", Integer, primary_key=True),
+        Column("PatientID", Integer),
+        Column("CentreActivityID", Integer),
+        Column("StartDateTime", DateTime),
+        Column("EndDateTime", DateTime),
+        Column("IsDeleted", Boolean),
+    )
     return schema
 
 
@@ -95,6 +105,7 @@ def fake_view_config(monkeypatch):
     for view_cls in (
         ActivitiesView,
         CompulsoryActivitiesOnlyView,
+        GroupActivitiesExclusionView,
         GroupActivitiesOnlyView,
         GroupActivitiesPreferenceView,
         GroupActivitiesRecommendationView,
@@ -122,6 +133,26 @@ class TestActivityDateRangeFiltering:
 
         assert f'"REF_CENTRE_ACTIVITY"."StartDate" <= \'{FIXED_SUNDAY}\'' in sql
         assert f'"REF_CENTRE_ACTIVITY"."EndDate" >= \'{FIXED_MONDAY}\'' in sql
+
+
+class TestGroupActivitiesExclusionViewWeekBoundary:
+    """GroupActivitiesExclusionView.build_query() computes its own week boundary inline
+    (not via get_monday()/get_next_sunday()) and used to roll over to next week's dates
+    whenever run on a Sunday, unlike every other week-boundary computation in the codebase."""
+
+    def test_sunday_uses_current_week_not_next_week(self, monkeypatch):
+        # Sunday 2024-03-24 is the last day of the week starting Monday 2024-03-18 (FIXED_MONDAY).
+        class FixedSundayDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return cls(2024, 3, 24, 10, 0, 0)
+
+        monkeypatch.setattr(views, "datetime", FixedSundayDatetime)
+
+        params = GroupActivitiesExclusionView.build_query().compile().params
+
+        assert params["EndDateTime_1"] == datetime(2024, 3, 18, 0, 0, 0)  # start_of_week
+        assert params["StartDateTime_1"] == datetime(2024, 3, 24, 23, 59, 59)  # end_of_week
 
 
 # 4 fake activities, one per date-range shape. All three of SPANS_WEEK, STARTS_MIDWEEK and

--- a/tests/unit_tests/test_views.py
+++ b/tests/unit_tests/test_views.py
@@ -100,8 +100,8 @@ def _make_fake_schema() -> MetaData:
 def fake_view_config(monkeypatch):
     """Point every affected view at an in-memory schema + fixed week boundaries, no DB connection involved."""
     monkeypatch.setattr(views.DB, "schema", _make_fake_schema(), raising=False)
-    monkeypatch.setattr(views, "get_monday", lambda: FIXED_MONDAY)
-    monkeypatch.setattr(views, "get_next_sunday", lambda: FIXED_SUNDAY)
+    monkeypatch.setattr(views, "get_week_start", lambda: FIXED_MONDAY)
+    monkeypatch.setattr(views, "get_week_end", lambda: FIXED_SUNDAY)
     for view_cls in (
         ActivitiesView,
         CompulsoryActivitiesOnlyView,
@@ -137,7 +137,7 @@ class TestActivityDateRangeFiltering:
 
 class TestGroupActivitiesExclusionViewWeekBoundary:
     """GroupActivitiesExclusionView.build_query() computes its own week boundary inline
-    (not via get_monday()/get_next_sunday()) and used to roll over to next week's dates
+    (not via get_week_start()/get_week_end()) and used to roll over to next week's dates
     whenever run on a Sunday, unlike every other week-boundary computation in the codebase."""
 
     def test_sunday_uses_current_week_not_next_week(self, monkeypatch):

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -2,6 +2,7 @@
 Tests for writer.py schedule labels.
 """
 
+import datetime
 import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -47,6 +48,56 @@ def _write(patientSchedules, config, monkeypatch):
 
 def _inserted_schedule_data(schedule_table):
     return schedule_table.insert.return_value.values.call_args[0][0]
+
+
+def _freeze_today(monkeypatch, fixed_now):
+    class FixedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+
+    fake_datetime_module = SimpleNamespace(
+        datetime=FixedDatetime, timedelta=datetime.timedelta, date=datetime.date
+    )
+    monkeypatch.setattr(writer_module, "datetime", fake_datetime_module)
+
+
+class TestPastDayProtection:
+    """Past days shouldn't get overwritten on regenerate."""
+
+    def test_regenerate_does_not_overwrite_past_days(self, monkeypatch):
+        config = _config(
+            OPEN_DAYS=["Monday", "Tuesday", "Wednesday"],
+            SLOTS_PER_DAY={"Monday": 1, "Tuesday": 1, "Wednesday": 1},
+            WORKING_HOURS={
+                "monday": {"open": "09:00", "close": "09:30"},
+                "tuesday": {"open": "09:00", "close": "09:30"},
+                "wednesday": {"open": "09:00", "close": "09:30"},
+            },
+        )
+        # Wednesday 2024-03-20, same week as Monday 2024-03-18.
+        _freeze_today(monkeypatch, datetime.datetime(2024, 3, 20, 10, 0, 0))
+
+        schedule_table = MagicMock()
+        fake_schema = MagicMock()
+        fake_schema.tables = {"SCHEDULE": schedule_table}
+        monkeypatch.setattr(writer_module.DB, "schema", fake_schema, raising=False)
+        monkeypatch.setattr(ScheduleWriter, "config", config, raising=False)
+
+        conn = MagicMock()
+        result = ScheduleWriter.write(
+            patientSchedules={"1": [["MonAct"], ["TueAct"], ["WedAct"]]},
+            medicationScheduleRef=_FakeMedicationScheduleRef(),
+            conn=conn,
+            overwriteExisting=True,
+            schedule_meta={"1": {"ScheduleID": 42}},
+        )
+
+        assert result is True
+        updated_data = schedule_table.update.return_value.values.call_args[0][0]
+        assert "Monday" not in updated_data
+        assert "Tuesday" not in updated_data
+        assert "Wednesday" in updated_data
 
 
 class TestScheduleLabeling:

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -84,20 +84,76 @@ class TestPastDayProtection:
         monkeypatch.setattr(writer_module.DB, "schema", fake_schema, raising=False)
         monkeypatch.setattr(ScheduleWriter, "config", config, raising=False)
 
-        conn = MagicMock()
-        result = ScheduleWriter.write(
-            patientSchedules={"1": [["MonAct"], ["TueAct"], ["WedAct"]]},
-            medicationScheduleRef=_FakeMedicationScheduleRef(),
-            conn=conn,
-            overwriteExisting=True,
-            schedule_meta={"1": {"ScheduleID": 42}},
-        )
+        with patch.object(writer_module.ExistingScheduleView, "get_data", return_value=pd.DataFrame()):
+            conn = MagicMock()
+            result = ScheduleWriter.write(
+                patientSchedules={"1": [["MonAct"], ["TueAct"], ["WedAct"]]},
+                medicationScheduleRef=_FakeMedicationScheduleRef(),
+                conn=conn,
+                overwriteExisting=True,
+                schedule_meta={"1": {"ScheduleID": 42}},
+            )
 
         assert result is True
         updated_data = schedule_table.update.return_value.values.call_args[0][0]
         assert "Monday" not in updated_data
         assert "Tuesday" not in updated_data
         assert "Wednesday" in updated_data
+
+    def test_regenerate_does_not_overwrite_past_medication_dates(self, monkeypatch):
+        config = _config(
+            OPEN_DAYS=["Monday", "Tuesday", "Wednesday"],
+            SLOTS_PER_DAY={"Monday": 1, "Tuesday": 1, "Wednesday": 1},
+            WORKING_HOURS={
+                "monday": {"open": "09:00", "close": "09:30"},
+                "tuesday": {"open": "09:00", "close": "09:30"},
+                "wednesday": {"open": "09:00", "close": "09:30"},
+            },
+        )
+        _freeze_today(monkeypatch, datetime.datetime(2024, 3, 20, 10, 0, 0))
+
+        schedule_table = MagicMock()
+        fake_schema = MagicMock()
+        fake_schema.tables = {"SCHEDULE": schedule_table}
+        monkeypatch.setattr(writer_module.DB, "schema", fake_schema, raising=False)
+        monkeypatch.setattr(ScheduleWriter, "config", config, raising=False)
+
+        existing_medication_schedule = json.dumps({
+            "2024-03-18": [{"MedicationID": 1, "Status": 1}],
+            "2024-03-19": [{"MedicationID": 2, "Status": 1}],
+        })
+        existing_row = pd.DataFrame([{
+            "ScheduleID": 42,
+            "MedicationSchedule": existing_medication_schedule,
+            "Monday": "{}", "Tuesday": "{}", "Wednesday": "{}",
+        }])
+
+        fresh_medication_schedule = {
+            "2024-03-18": [{"MedicationID": 1, "Status": 0}],
+            "2024-03-19": [{"MedicationID": 2, "Status": 0}],
+            "2024-03-20": [{"MedicationID": 3, "Status": 0}],
+        }
+
+        class _FakeMedicationScheduleRefWithData:
+            def reformatMedicationScheduleData(self, _cls):
+                return {1: fresh_medication_schedule}
+
+        with patch.object(writer_module.ExistingScheduleView, "get_data", return_value=existing_row):
+            conn = MagicMock()
+            result = ScheduleWriter.write(
+                patientSchedules={"1": [["MonAct"], ["TueAct"], ["WedAct"]]},
+                medicationScheduleRef=_FakeMedicationScheduleRefWithData(),
+                conn=conn,
+                overwriteExisting=True,
+                schedule_meta={"1": {"ScheduleID": 42}},
+            )
+
+        assert result is True
+        updated_data = schedule_table.update.return_value.values.call_args[0][0]
+        merged = json.loads(updated_data["MedicationSchedule"])
+        assert merged["2024-03-18"] == [{"MedicationID": 1, "Status": 1}]
+        assert merged["2024-03-19"] == [{"MedicationID": 2, "Status": 1}]
+        assert merged["2024-03-20"] == [{"MedicationID": 3, "Status": 0}]
 
 
 class TestScheduleLabeling:


### PR DESCRIPTION
- Reinstated the doctor-recommended activity expiry filter (was commented out), null-safe
- Fixed group activity exclusions checking next week's date range instead of the current week on Sundays
- Fixed `get_next_sunday()` (renamed `get_week_end()`) jumping to next week when run on a Sunday, to match `get_monday()`/`get_week_start()`
- Stopped regenerate from overwriting past days in the schedule row
- Stopped regenerate from overwriting past medication schedule data