### PR TITLE
Consolidate week math and fix medication end_of_week hardcoded to Friday

### DIFF
--- a/pear_schedule/db_utils/utils.py
+++ b/pear_schedule/db_utils/utils.py
@@ -6,17 +6,16 @@ def compile_query(query: Select) -> str:
     # literal binds might cause errors if datetime is ever used
     return query.compile(compile_kwargs={"literal_binds": True})
 
-def get_week_start():
+def get_week_start() -> datetime:
     today = datetime.now()
-    monday = (today - timedelta(days=today.weekday())).strftime("%Y-%m-%d")
-    return monday
+    monday = today - timedelta(days=today.weekday())
+    return monday.replace(hour=0, minute=0, second=0, microsecond=0)
 
-def get_week_end():
+def get_week_end() -> datetime:
     today = datetime.now()
     days_until_sunday = 6 - today.weekday()
     sunday = today + timedelta(days=days_until_sunday)
-    sunday = sunday.replace(hour=23, minute=59, second=59)
-    return sunday
+    return sunday.replace(hour=23, minute=59, second=59, microsecond=0)
 
 def timeslot_index(offset: timedelta, duration_minutes: int) -> int:
     """Floor-divide a clock-time offset by a slot duration to get a 0-based slot index.

--- a/pear_schedule/db_utils/writer.py
+++ b/pear_schedule/db_utils/writer.py
@@ -7,7 +7,7 @@ from typing import Mapping, List, Dict
 
 from sqlalchemy import Connection, column, delete, select, func, literal_column, column
 from pear_schedule.db import DB
-from pear_schedule.db_utils.utils import day_timeslot_labels
+from pear_schedule.db_utils.utils import day_timeslot_labels, get_week_start, get_week_end
 from pear_schedule.db_utils.views import ExistingScheduleView, DeletedMedicationView, WeeklyScheduleView
 from pear_schedule.scheduler.medicationScheduling import medicationScheduleData
 from pear_schedule.utils import ConfigDependant, DBTABLES
@@ -88,9 +88,8 @@ class ScheduleWriter(ConfigDependant):
         schedule_table = DB.schema.tables[db_tables.SCHEDULE_TABLE]
 
         today = datetime.datetime.now()
-        start_of_week = today - datetime.timedelta(days=today.weekday())  # Monday -> 00:00:00
-        start_of_week = start_of_week.replace(hour=0, minute=0, second=0, microsecond=0)
-        end_of_week = start_of_week + datetime.timedelta(days=6, hours=23, minutes=59, seconds=59, microseconds=0)  # Sunday -> 23:59:59
+        start_of_week = get_week_start()
+        end_of_week = get_week_end()
         past_days = _past_day_columns(start_of_week, today)
         past_medication_dates = _past_medication_dates(start_of_week, today, cls.config["STD_DATE_FORMAT"])
 
@@ -299,7 +298,7 @@ class MedicationScheduleWrite(ConfigDependant):
 
         # Need to get the ScheduleID, retrieve existing schedule
         today = datetime.datetime.now()
-        start_of_week = datetime.datetime.combine(today.date() - datetime.timedelta(days=today.weekday()), datetime.datetime.min.time()) # Monday 00:00:00
+        start_of_week = get_week_start()
         # get existing schedules for the week for all patients, pid should be unique in this df
         existingSchedules: pd.DataFrame = ExistingScheduleView.get_data(conn=conn, start_dateTime=start_of_week)
 
@@ -340,10 +339,9 @@ class MedicationScheduleWrite(ConfigDependant):
     @classmethod
     def __writeRecordsUsingSchedules(cls, conn: Connection, schedules: Mapping[int, List[int]]) -> bool:
         today = datetime.datetime.now()
-        start_of_week = today - datetime.timedelta(days=today.weekday())  # Monday -> 00:00:00
-        start_of_week = start_of_week.replace(hour=0, minute=0, second=0, microsecond=0)
-        end_of_week = start_of_week + datetime.timedelta(days=6, hours=23, minutes=59, seconds=59, microseconds=0)  # Sunday -> 23:59:59
-        
+        start_of_week = get_week_start()
+        end_of_week = get_week_end()
+
         schedule_table = DB.schema.tables[cls.config["DB_TABLES"].SCHEDULE_TABLE]
         for patient_id, meds in schedules.items():
           if len(meds) == 0: continue

--- a/pear_schedule/scheduler/medicationScheduling.py
+++ b/pear_schedule/scheduler/medicationScheduling.py
@@ -34,7 +34,7 @@ class medicationScheduleData:
             today = datetime.datetime.now()
             start_of_week = today - datetime.timedelta(days=today.weekday())  # Monday -> 00:00:00
             start_of_week = start_of_week.replace(hour=0, minute=0, second=0, microsecond=0)
-            end_of_week = start_of_week + datetime.timedelta(days=4, hours=23, minutes=59, seconds=59, microseconds=0)  # Sunday -> 23:59:59
+            end_of_week = start_of_week + datetime.timedelta(days=len(cls.config["OPEN_DAYS"]) - 1, hours=23, minutes=59, seconds=59, microseconds=0)  # last open day -> 23:59:59
             
             if startDateTime <= start_of_week: # Medication starts either before or start of this week
                 pass

--- a/tests/unit_tests/test_db_utils_utils.py
+++ b/tests/unit_tests/test_db_utils_utils.py
@@ -19,14 +19,14 @@ class TestGetWeekStartAndGetWeekEnd:
         # Sunday 2024-03-24 is the last day of the week starting Monday 2024-03-18.
         self._freeze(monkeypatch, datetime(2024, 3, 24, 10, 0, 0))
 
-        assert utils.get_week_start() == "2024-03-18"
+        assert utils.get_week_start() == datetime(2024, 3, 18, 0, 0, 0)
         assert utils.get_week_end() == datetime(2024, 3, 24, 23, 59, 59)
 
     def test_midweek_day_still_returns_current_week_sunday(self, monkeypatch):
         # Wednesday 2024-03-20, same week as above.
         self._freeze(monkeypatch, datetime(2024, 3, 20, 10, 0, 0))
 
-        assert utils.get_week_start() == "2024-03-18"
+        assert utils.get_week_start() == datetime(2024, 3, 18, 0, 0, 0)
         assert utils.get_week_end() == datetime(2024, 3, 24, 23, 59, 59)
 
 

--- a/tests/unit_tests/test_medication_scheduling.py
+++ b/tests/unit_tests/test_medication_scheduling.py
@@ -33,10 +33,6 @@ def _freeze_now(monkeypatch, fixed_now=FIXED_NOW):
     monkeypatch.setattr("pear_schedule.scheduler.medicationScheduling.datetime", fake_ns)
     yield
 
-# __getMedicationSchedulingData hardcodes end_of_week assuming exactly 5 OPEN_DAYS
-# (medicationScheduling.py ~36) - sticking to 5 OPEN_DAYS everywhere here so we don't
-# trip over that separate issue
-
 OPEN_DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
 
 
@@ -234,6 +230,53 @@ class TestMedicationSchedulerFillSchedule:
             medicationScheduler.fillSchedule(patient_schedules)
 
         assert "**Take with food" in patient_schedules[1][0][0]
+
+    def test_medication_ending_mid_week_stops_on_correct_day_with_six_open_days(self, monkeypatch):
+        """end_of_week was hardcoded to Friday, drifting the cutoff into Thursday on a 6-open-day week."""
+        six_day_open_days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+        six_day_config = make_scheduler_config(
+            OPEN_DAYS=six_day_open_days,
+            SLOTS_PER_DAY={day: 8 for day in six_day_open_days},
+            WORKING_HOURS={day.lower(): {"open": "09:00", "close": "13:00"} for day in six_day_open_days},
+        )
+        monkeypatch.setattr(medicationScheduler, "config", six_day_config, raising=False)
+        patient_schedules = {1: [["" for _ in range(8)] for _ in range(6)]}
+
+        row = _medication_row(
+            end_datetime=START_OF_WEEK + datetime.timedelta(days=2, hours=23, minutes=59, seconds=59)  # end of Wednesday
+        )
+
+        with _freeze_now(monkeypatch), \
+             patch("pear_schedule.db_utils.views.MedicationView.get_data", return_value=row), \
+             patch("pear_schedule.db_utils.views.CaregiverAllocatedView.get_data", return_value=_empty_caregiver_df()):
+            medicationScheduler.fillSchedule(patient_schedules)
+
+        assert "Give Medication" in patient_schedules[1][0][0]  # Monday
+        assert "Give Medication" in patient_schedules[1][1][0]  # Tuesday
+        assert "Give Medication" in patient_schedules[1][2][0]  # Wednesday
+        assert patient_schedules[1][3][0] == ""  # Thursday - after end, untouched
+        assert patient_schedules[1][4][0] == ""  # Friday - after end, untouched
+        assert patient_schedules[1][5][0] == ""  # Saturday - after end, untouched
+
+    def test_medication_starting_on_last_open_day_with_six_open_days(self, monkeypatch):
+        """Same wrong end_of_week also skipped medications starting on the 6th open day, Saturday."""
+        six_day_open_days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+        six_day_config = make_scheduler_config(
+            OPEN_DAYS=six_day_open_days,
+            SLOTS_PER_DAY={day: 8 for day in six_day_open_days},
+            WORKING_HOURS={day.lower(): {"open": "09:00", "close": "13:00"} for day in six_day_open_days},
+        )
+        monkeypatch.setattr(medicationScheduler, "config", six_day_config, raising=False)
+        patient_schedules = {1: [["" for _ in range(8)] for _ in range(6)]}
+
+        row = _medication_row(start_datetime=START_OF_WEEK + datetime.timedelta(days=5))  # Saturday
+
+        with _freeze_now(monkeypatch), \
+             patch("pear_schedule.db_utils.views.MedicationView.get_data", return_value=row), \
+             patch("pear_schedule.db_utils.views.CaregiverAllocatedView.get_data", return_value=_empty_caregiver_df()):
+            medicationScheduler.fillSchedule(patient_schedules)
+
+        assert "Give Medication" in patient_schedules[1][5][0]  # Saturday - should not be skipped
 
     def test_out_of_bounds_slot_skipped_without_error(self, monkeypatch):
         monkeypatch.setattr(medicationScheduler, "config", _config(), raising=False)

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 
 from configprod import DAY_TIMESLOTS
+from pear_schedule.db_utils import utils as db_utils_module
 from pear_schedule.db_utils import writer as writer_module
 from pear_schedule.db_utils.writer import ScheduleWriter
 from tests.utils.scheduler_config import make_scheduler_config
@@ -60,6 +61,8 @@ def _freeze_today(monkeypatch, fixed_now):
         datetime=FixedDatetime, timedelta=datetime.timedelta, date=datetime.date
     )
     monkeypatch.setattr(writer_module, "datetime", fake_datetime_module)
+    # get_week_start()/get_week_end() live in db_utils.utils, freeze its datetime too
+    monkeypatch.setattr(db_utils_module, "datetime", FixedDatetime)
 
 
 class TestPastDayProtection:
@@ -154,6 +157,23 @@ class TestPastDayProtection:
         assert merged["2024-03-18"] == [{"MedicationID": 1, "Status": 1}]
         assert merged["2024-03-19"] == [{"MedicationID": 2, "Status": 1}]
         assert merged["2024-03-20"] == [{"MedicationID": 3, "Status": 0}]
+
+
+class TestWeekBoundaries:
+    """__writeToDB's StartDate/EndDate come from the shared get_week_start()/get_week_end()."""
+
+    def test_start_and_end_date_match_shared_week_helpers(self, monkeypatch):
+        config = _config()
+        # Wednesday 2024-03-20, week of Monday 2024-03-18 - Sunday 2024-03-24.
+        _freeze_today(monkeypatch, datetime.datetime(2024, 3, 20, 10, 0, 0))
+
+        patientSchedules = {"1": [["MonAct"], ["TueAct"]]}
+        result, schedule_table = _write(patientSchedules, config, monkeypatch)
+
+        assert result is True
+        schedule_data = _inserted_schedule_data(schedule_table)
+        assert schedule_data["StartDate"] == datetime.datetime(2024, 3, 18, 0, 0, 0)
+        assert schedule_data["EndDate"] == datetime.datetime(2024, 3, 24, 23, 59, 59)
 
 
 class TestScheduleLabeling:


### PR DESCRIPTION
- Consolidated writer.py's 3 duplicated start/end-of-week computations onto the shared get_week_start()/get_week_end() helpers
- Fixed medication scheduling's end_of_week being hardcoded to Friday regardless of OPEN_DAYS, which drifted end dates late and skipped start dates on the 6th open day for weeks with more than 5 open days