### PR TITLE
change prod cd to use reusable workflow basecd.yml

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -1,4 +1,4 @@
-name: CD-Prod
+name: CD (Production)
 
 on:
   push:
@@ -8,91 +8,21 @@ permissions:
   contents: read
 
 jobs:
-  precheck:
-    if: github.ref == 'refs/heads/scheduler_prod'
-    runs-on: [self-hosted, Linux, X64, scheduler]
-    steps:
-      - name: Check kubectl permissions
-        run: |
-          echo "Checking Kubernetes permissions..."
-          kubectl auth can-i delete deployments || (echo "No permission to delete deployments" && exit 1)
-          kubectl auth can-i create deployments || (echo "No permission to create deployments" && exit 1)
-      - name: Check Docker registry access
-        run: |
-          echo "Checking Docker registry access..."
-          docker info || (echo "Docker not accessible" && exit 1)
-
-  deploy:
-    if: github.ref == 'refs/heads/scheduler_prod'
-    needs: precheck
-    runs-on: [self-hosted, Linux, X64, scheduler]
-
-    env:
-      DB_SERVER_DEV: ${{ secrets.DB_SERVER_DEV }}
-      DB_DATABASE_DEV: ${{ secrets.DB_DATABASE_DEV }}
-      DB_DATABASE_PORT: ${{ secrets.DB_DATABASE_PORT }}
-      DB_USERNAME_DEV: ${{ secrets.DB_USERNAME_DEV }}
-      DB_PASSWORD_DEV: ${{ secrets.DB_PASSWORD_DEV }}
-      DB_DRIVER_DEV: ${{ secrets.DB_DRIVER_DEV }}
-      RABBITMQ_HOST: ${{ secrets.RABBITMQ_HOST }}
-      RABBITMQ_PORT: ${{ secrets.RABBITMQ_PORT }}
-      RABBITMQ_USER: ${{ secrets.RABBITMQ_USER }}
-      RABBITMQ_PASS: ${{ secrets.RABBITMQ_PASS }}
-      RABBITMQ_VIRTUAL_HOST: ${{ secrets.RABBITMQ_VIRTUAL_HOST }}
-      WEB_FE_ORIGIN: ${{ secrets.WEB_FE_ORIGIN }}
-      WEB_FE_ORIGIN_STAGING: ${{ secrets.WEB_FE_ORIGIN_STAGING }}
-      USER_BE_ORIGIN: ${{ secrets.USER_BE_ORIGIN }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Create .env file from GitHub Secrets
-        run: |
-          echo "DB_DRIVER_DEV=${{ secrets.DB_DRIVER_DEV }}" >> .env
-          echo "DB_SERVER_DEV=${{ secrets.DB_SERVER_DEV }}" >> .env
-          echo "DB_DATABASE_DEV=${{ secrets.DB_DATABASE_DEV }}" >> .env
-          echo "DB_DATABASE_PORT=${{ secrets.DB_DATABASE_PORT }}" >> .env
-          echo "DB_USERNAME_DEV=${{ secrets.DB_USERNAME_DEV }}" >> .env
-          echo "DB_PASSWORD_DEV=${{ secrets.DB_PASSWORD_DEV }}" >> .env
-          echo "RABBITMQ_HOST=${{ secrets.RABBITMQ_HOST }}" >> .env
-          echo "RABBITMQ_PORT=${{ secrets.RABBITMQ_PORT }}" >> .env
-          echo "RABBITMQ_USER=${{ secrets.RABBITMQ_USER }}" >> .env
-          echo "RABBITMQ_PASS=${{ secrets.RABBITMQ_PASS }}" >> .env
-          echo "RABBITMQ_VIRTUAL_HOST=${{ secrets.RABBITMQ_VIRTUAL_HOST }}" >> .env
-          echo "WEB_FE_ORIGIN=${{ secrets.WEB_FE_ORIGIN }}" >> .env
-          echo "WEB_FE_ORIGIN_STAGING=${{ secrets.WEB_FE_ORIGIN_STAGING }}" >> .env
-          echo "USER_BE_ORIGIN=${{ secrets.USER_BE_ORIGIN }}" >> .env
-
-      - name: Create/Update ConfigMap in Kubernetes
-        run: |
-          kubectl create configmap scheduler-service-dev-env \
-            --from-env-file=.env \
-            --dry-run=client -o yaml | kubectl apply -f -
-
-      - name: Delete old deployment and service
-        run: |
-          kubectl delete deployment scheduler-service-dev -n default --ignore-not-found
-
-      - name: Delete old Docker images
-        run: |
-          docker rmi scheduler_service_dev || true
-          docker rmi localhost:5000/scheduler_service_dev || true
-
-      - name: Build Docker image
-        run: |
-          docker build --no-cache -f Dockerfile.dev -t scheduler_service_dev:latest .
-
-      - name: Tag Docker image for local registry
-        run: |
-          docker tag scheduler_service_dev:latest localhost:5000/scheduler_service_dev:latest
-
-      - name: Push Docker image to local registry
-        run: |
-          docker push localhost:5000/scheduler_service_dev:latest
-
-      - name: Deploy to Kubernetes
-        run: |
-          kubectl apply -f ./k8s/scheduler_deployment_dev.yaml
-          
-      - name: Deploy CronJob (scheduler_cronjob.yaml)
-        run: |
-          kubectl apply -f ./k8s/scheduler_cronjob.yaml
+  deploy-prod:
+    uses: ./.github/workflows/base-cd.yaml
+    # `secrets: inherit` lets base-cd reach the environment secrets. The values
+    # themselves are read inside base-cd, whose jobs declare `environment:` -
+    # this job cannot, which is why no vars/secrets are listed here.
+    secrets: inherit
+    with:
+      # must match the GitHub Environment name exactly (case-sensitive)
+      environment: 'prod'
+      runner-label: '["self-hosted","Linux","X64","scheduler"]'
+      namespace: 'default'
+      deployment-name: 'scheduler-service-dev'
+      container-name: 'scheduler-service-dev'
+      configmap-name: 'scheduler-service-dev-env'
+      docker-image-name: 'scheduler_service_dev'
+      kube-deployment-file: './k8s/scheduler_deployment_dev.yaml'
+      kube-cronjob-file: './k8s/scheduler_cronjob.yaml'
+      dockerfile: 'Dockerfile.dev'


### PR DESCRIPTION
This pull request refactors the production deployment workflow for the scheduler service to use a reusable workflow for improved maintainability and consistency. The previous inline deployment logic is replaced with a call to a shared workflow, and the job and workflow naming are updated for clarity.

**Workflow refactoring and simplification:**

* The entire inline deployment process (`precheck` and `deploy` jobs) in `.github/workflows/cd-prod.yml` is removed and replaced with a single `deploy-prod` job that uses the reusable workflow `.github/workflows/base-cd.yaml`. This change centralizes deployment logic, reduces duplication, and makes future updates easier.
* The workflow name is updated from `CD-Prod` to `CD (Production)` for improved clarity.

**Reusable workflow integration:**

* The new `deploy-prod` job passes all necessary deployment parameters (such as environment, runner label, namespace, deployment and container names, configmap name, Docker image name, Kubernetes deployment and cronjob files, and Dockerfile) to the reusable workflow, and inherits secrets for secure access.


