### PR TITLE
Register AdhocConsumer so REF_ADHOC actually gets adhoc events

### DIFF
--- a/messaging/consumer_manager.py
+++ b/messaging/consumer_manager.py
@@ -197,8 +197,7 @@ def create_scheduler_consumer_manager() -> ConsumerManager:
     manager.register_consumer("activity_preference", ActivityPreferenceConsumer)
     manager.register_consumer("activity_recommendation", ActivityRecommendationConsumer)
     manager.register_consumer("centre_activity", CentreActivityConsumer)
-    # TODO: register adhoc consumer when ready
-    # manager.register_consumer("adhoc", AdhocConsumer)
+    manager.register_consumer("adhoc", AdhocConsumer)
     
     return manager
 


### PR DESCRIPTION
- AdhocConsumer was fully implemented and imported but its registration in create_scheduler_consumer_manager() was commented out with a TODO, so it never started on any deployment and REF_ADHOC never received any adhoc data regardless of what the Activity service sent
- Confirmed live via kubectl logs on staging: zero AdhocConsumer activity across the pod's entire uptime, versus other consumers processing messages normally in the same window